### PR TITLE
fix: improve GitHub Actions cache configuration

### DIFF
--- a/.github/workflows/ci-comprehensive.yml
+++ b/.github/workflows/ci-comprehensive.yml
@@ -30,15 +30,26 @@ jobs:
         go-version: '1.23'
 
     - name: Cache dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
         restore-keys: |
+          ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-
           ${{ runner.os }}-go-
 
+    - name: Clean Go cache on cache restore failure
+      if: failure()
+      run: |
+        echo "Cleaning Go module cache due to restore failure..."
+        go clean -modcache
+
     - name: Install dependencies
-      run: go mod download
+      run: |
+        go mod download
+        go mod verify
 
     - name: Run format check
       run: |
@@ -237,15 +248,26 @@ jobs:
         go-version: '1.23'
 
     - name: Cache dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
         restore-keys: |
+          ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-
           ${{ runner.os }}-go-
 
+    - name: Clean Go cache on cache restore failure
+      if: failure()
+      run: |
+        echo "Cleaning Go module cache due to restore failure..."
+        go clean -modcache
+
     - name: Install dependencies
-      run: go mod download
+      run: |
+        go mod download
+        go mod verify
 
     - name: Build for development
       if: github.ref == 'refs/heads/develop'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,15 +47,26 @@ jobs:
         echo "BUILD_USER=github-actions" >> $GITHUB_OUTPUT
 
     - name: Cache dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
         restore-keys: |
+          ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-
           ${{ runner.os }}-go-
 
+    - name: Clean Go cache on cache restore failure
+      if: failure()
+      run: |
+        echo "Cleaning Go module cache due to restore failure..."
+        go clean -modcache
+
     - name: Install dependencies
-      run: go mod download
+      run: |
+        go mod download
+        go mod verify
 
     - name: Run tests
       run: |


### PR DESCRIPTION
## Problem
The release workflow (v1.2.2) experienced cache restoration failures with multiple 'Cannot open: File exists' errors during Go module cache extraction.

## Solution
- **Upgrade**: actions/cache v3 → v4 for better reliability
- **Enhanced Cache Key**: Include go.mod hash for precise invalidation  
- **Expanded Cache Paths**: Add ~/.cache/go-build for build optimization
- **Fallback Cleanup**: Auto-clean cache on restore failures
- **Verification**: Add go mod verify for integrity validation

## Testing
This PR tests the workflow improvements before merging to main.

**No release artifacts will be created** - this is purely for CI testing.