### PR TITLE
fix(prompt): remove AIService zombie content param (#43) + route ephemeral bulk apply through BulkPromptService (#44)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"5a98f660-5fe8-4661-90f9-cc7e2fd1f50a","pid":1861168,"procStart":"336443244","acquiredAt":1780480724606}

--- a/internal/services/ai_service.go
+++ b/internal/services/ai_service.go
@@ -289,13 +289,12 @@ func (s *AIServiceImpl) FormatContent(ctx context.Context, content string, optio
 	return formatted, nil
 }
 
-func (s *AIServiceImpl) ApplyCustomPrompt(ctx context.Context, content string, prompt string, variables map[string]string) (string, error) {
+// ApplyCustomPrompt runs a fully-formed, self-contained prompt against the provider.
+// The prompt must already have any email content/variables substituted in by the caller
+// (see prompt_service, bulk_prompt_service, prompt_generator_service).
+func (s *AIServiceImpl) ApplyCustomPrompt(ctx context.Context, prompt string, variables map[string]string) (string, error) {
 	if s.provider == nil {
 		return "", fmt.Errorf("AI provider not available")
-	}
-
-	if strings.TrimSpace(content) == "" {
-		return "", fmt.Errorf("content cannot be empty")
 	}
 
 	if strings.TrimSpace(prompt) == "" {
@@ -311,13 +310,10 @@ func (s *AIServiceImpl) ApplyCustomPrompt(ctx context.Context, content string, p
 	return result, nil
 }
 
-// ApplyCustomPromptStream applies a custom prompt with streaming support
-func (s *AIServiceImpl) ApplyCustomPromptStream(ctx context.Context, content string, prompt string, variables map[string]string, onToken func(string)) (string, error) {
+// ApplyCustomPromptStream applies a self-contained custom prompt with streaming support.
+func (s *AIServiceImpl) ApplyCustomPromptStream(ctx context.Context, prompt string, variables map[string]string, onToken func(string)) (string, error) {
 	if s.provider == nil {
 		return "", fmt.Errorf("AI provider not available")
-	}
-	if strings.TrimSpace(content) == "" {
-		return "", fmt.Errorf("content cannot be empty")
 	}
 	if strings.TrimSpace(prompt) == "" {
 		return "", fmt.Errorf("prompt cannot be empty")
@@ -344,5 +340,5 @@ func (s *AIServiceImpl) ApplyCustomPromptStream(ctx context.Context, content str
 	}
 
 	// Fallback to non-streaming if not supported
-	return s.ApplyCustomPrompt(ctx, content, prompt, variables)
+	return s.ApplyCustomPrompt(ctx, prompt, variables)
 }

--- a/internal/services/bulk_prompt_service.go
+++ b/internal/services/bulk_prompt_service.go
@@ -102,7 +102,7 @@ func (s *BulkPromptServiceImpl) ApplyBulkPrompt(
 	// Build the final prompt with the actual template and content
 	finalPrompt := s.buildBulkPrompt(promptTemplate.PromptText, combinedContent, variables)
 
-	result, err := s.aiService.ApplyCustomPrompt(ctx, combinedContent, finalPrompt, variables)
+	result, err := s.aiService.ApplyCustomPrompt(ctx, finalPrompt, variables)
 	if err != nil {
 		return nil, fmt.Errorf("failed to apply bulk prompt: %w", err)
 	}
@@ -196,7 +196,7 @@ func (s *BulkPromptServiceImpl) ApplyBulkPromptStream(ctx context.Context, accou
 		// Access logger through app context if possible - for now use simple logging
 		_ = s.promptService // Acknowledge service is available but not used here
 	}
-	result, err := s.aiService.ApplyCustomPromptStream(ctx, combinedContent, finalPrompt, variables, func(token string) {
+	result, err := s.aiService.ApplyCustomPromptStream(ctx, finalPrompt, variables, func(token string) {
 		// Call the original callback
 		if onToken != nil {
 			onToken(token)

--- a/internal/services/bulk_prompt_service.go
+++ b/internal/services/bulk_prompt_service.go
@@ -224,6 +224,49 @@ func (s *BulkPromptServiceImpl) ApplyBulkPromptStream(ctx context.Context, accou
 	}, nil
 }
 
+// ApplyEphemeralBulkPromptStream applies an unsaved prompt (raw text, no DB template) to
+// multiple messages with streaming. It reuses the same content extraction, cleaning, and
+// combination logic as ApplyBulkPromptStream so that ephemeral applies (from the prompt
+// configurator) produce identical LLM input to saved-prompt applies. No caching is done
+// because the prompt has no stable ID. Returns the final result text.
+func (s *BulkPromptServiceImpl) ApplyEphemeralBulkPromptStream(ctx context.Context, messageIDs []string, promptText string, variables map[string]string, onToken func(string)) (string, error) {
+	if s.aiService == nil || s.repository == nil {
+		return "", fmt.Errorf("bulk prompt service not fully initialized")
+	}
+
+	messageContents := make([]string, 0, len(messageIDs))
+	successfulIDs := make([]string, 0, len(messageIDs))
+	for _, messageID := range messageIDs {
+		message, err := s.repository.GetMessage(ctx, messageID)
+		if err != nil {
+			continue // Skip failed messages, don't fail the entire operation
+		}
+		content := s.extractMessageContent(message)
+		if content != "" {
+			messageContents = append(messageContents, content)
+			successfulIDs = append(successfulIDs, messageID)
+		}
+	}
+
+	if len(messageContents) == 0 {
+		return "", fmt.Errorf("no valid messages found")
+	}
+
+	// Same combine (with cleanEmailContent) + placeholder substitution as the saved path.
+	combinedContent := s.combineMessageContents(messageContents, successfulIDs)
+	finalPrompt := s.buildBulkPrompt(promptText, combinedContent, variables)
+
+	result, err := s.aiService.ApplyCustomPromptStream(ctx, finalPrompt, variables, func(token string) {
+		if onToken != nil {
+			onToken(token)
+		}
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to apply bulk prompt with streaming: %w", err)
+	}
+	return result, nil
+}
+
 // extractMessageContent extracts the main content from a Gmail message
 func (s *BulkPromptServiceImpl) extractMessageContent(message *gmail.Message) string {
 	if message == nil {
@@ -341,14 +384,19 @@ func (s *BulkPromptServiceImpl) cleanEmailContent(content string) string {
 
 // buildBulkPrompt builds a prompt specifically for bulk analysis
 func (s *BulkPromptServiceImpl) buildBulkPrompt(promptText string, combinedContent string, variables map[string]string) string {
-	// Use the actual prompt template from the database
 	prompt := promptText
 
-	// Always replace {{messages}} with the combined content
-	prompt = strings.ReplaceAll(prompt, "{{messages}}", combinedContent)
-
-	// Also replace {{body}} for backward compatibility (in case some prompts still use it)
-	prompt = strings.ReplaceAll(prompt, "{{body}}", combinedContent)
+	// If the prompt declares a content placeholder, substitute the combined emails into it.
+	// {{body}} is accepted as a backward-compatible alias for {{messages}}.
+	hasPlaceholder := strings.Contains(prompt, "{{messages}}") || strings.Contains(prompt, "{{body}}")
+	if hasPlaceholder {
+		prompt = strings.ReplaceAll(prompt, "{{messages}}", combinedContent)
+		prompt = strings.ReplaceAll(prompt, "{{body}}", combinedContent)
+	} else {
+		// No placeholder (e.g. a hand-typed or LLM-generated prompt that forgot it):
+		// append the emails so the model still receives them instead of asking for content.
+		prompt = prompt + "\n\n" + combinedContent
+	}
 
 	// Replace any other variables in the prompt
 	for key, value := range variables {

--- a/internal/services/interfaces.go
+++ b/internal/services/interfaces.go
@@ -66,8 +66,8 @@ type AIService interface {
 	GenerateReply(ctx context.Context, content string, options ReplyOptions) (string, error)
 	SuggestLabels(ctx context.Context, content string, availableLabels []string) ([]string, error)
 	FormatContent(ctx context.Context, content string, options FormatOptions) (string, error)
-	ApplyCustomPrompt(ctx context.Context, content string, prompt string, variables map[string]string) (string, error)
-	ApplyCustomPromptStream(ctx context.Context, content string, prompt string, variables map[string]string, onToken func(string)) (string, error)
+	ApplyCustomPrompt(ctx context.Context, prompt string, variables map[string]string) (string, error)
+	ApplyCustomPromptStream(ctx context.Context, prompt string, variables map[string]string, onToken func(string)) (string, error)
 }
 
 // CacheService handles caching operations

--- a/internal/services/mocks/ai_service.go
+++ b/internal/services/mocks/ai_service.go
@@ -14,9 +14,9 @@ type AIService struct {
 	mock.Mock
 }
 
-// ApplyCustomPrompt provides a mock function with given fields: ctx, content, prompt, variables
-func (_m *AIService) ApplyCustomPrompt(ctx context.Context, content string, prompt string, variables map[string]string) (string, error) {
-	ret := _m.Called(ctx, content, prompt, variables)
+// ApplyCustomPrompt provides a mock function with given fields: ctx, prompt, variables
+func (_m *AIService) ApplyCustomPrompt(ctx context.Context, prompt string, variables map[string]string) (string, error) {
+	ret := _m.Called(ctx, prompt, variables)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ApplyCustomPrompt")
@@ -24,17 +24,17 @@ func (_m *AIService) ApplyCustomPrompt(ctx context.Context, content string, prom
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, map[string]string) (string, error)); ok {
-		return rf(ctx, content, prompt, variables)
+	if rf, ok := ret.Get(0).(func(context.Context, string, map[string]string) (string, error)); ok {
+		return rf(ctx, prompt, variables)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, map[string]string) string); ok {
-		r0 = rf(ctx, content, prompt, variables)
+	if rf, ok := ret.Get(0).(func(context.Context, string, map[string]string) string); ok {
+		r0 = rf(ctx, prompt, variables)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, map[string]string) error); ok {
-		r1 = rf(ctx, content, prompt, variables)
+	if rf, ok := ret.Get(1).(func(context.Context, string, map[string]string) error); ok {
+		r1 = rf(ctx, prompt, variables)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -42,9 +42,9 @@ func (_m *AIService) ApplyCustomPrompt(ctx context.Context, content string, prom
 	return r0, r1
 }
 
-// ApplyCustomPromptStream provides a mock function with given fields: ctx, content, prompt, variables, onToken
-func (_m *AIService) ApplyCustomPromptStream(ctx context.Context, content string, prompt string, variables map[string]string, onToken func(string)) (string, error) {
-	ret := _m.Called(ctx, content, prompt, variables, onToken)
+// ApplyCustomPromptStream provides a mock function with given fields: ctx, prompt, variables, onToken
+func (_m *AIService) ApplyCustomPromptStream(ctx context.Context, prompt string, variables map[string]string, onToken func(string)) (string, error) {
+	ret := _m.Called(ctx, prompt, variables, onToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ApplyCustomPromptStream")
@@ -52,17 +52,17 @@ func (_m *AIService) ApplyCustomPromptStream(ctx context.Context, content string
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, map[string]string, func(string)) (string, error)); ok {
-		return rf(ctx, content, prompt, variables, onToken)
+	if rf, ok := ret.Get(0).(func(context.Context, string, map[string]string, func(string)) (string, error)); ok {
+		return rf(ctx, prompt, variables, onToken)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, map[string]string, func(string)) string); ok {
-		r0 = rf(ctx, content, prompt, variables, onToken)
+	if rf, ok := ret.Get(0).(func(context.Context, string, map[string]string, func(string)) string); ok {
+		r0 = rf(ctx, prompt, variables, onToken)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, map[string]string, func(string)) error); ok {
-		r1 = rf(ctx, content, prompt, variables, onToken)
+	if rf, ok := ret.Get(1).(func(context.Context, string, map[string]string, func(string)) error); ok {
+		r1 = rf(ctx, prompt, variables, onToken)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/internal/services/prompt_generator_service.go
+++ b/internal/services/prompt_generator_service.go
@@ -30,7 +30,7 @@ func (s *PromptGeneratorServiceImpl) GenerateFromIntent(ctx context.Context, int
 	metaPrompt := s.buildGenerationPrompt(intent, opts)
 
 	// AIService validates content non-empty but only uses prompt; pass intent as content.
-	raw, err := s.aiService.ApplyCustomPrompt(ctx, intent, metaPrompt, nil)
+	raw, err := s.aiService.ApplyCustomPrompt(ctx, metaPrompt, nil)
 	if err != nil {
 		return nil, fmt.Errorf("LLM generation failed: %w", err)
 	}
@@ -58,7 +58,7 @@ func (s *PromptGeneratorServiceImpl) RefinePrompt(ctx context.Context, currentPr
 	metaPrompt := s.buildRefinementPrompt(currentPrompt, refinement, opts)
 
 	// AIService validates content non-empty but only uses prompt; pass currentPrompt as content.
-	raw, err := s.aiService.ApplyCustomPrompt(ctx, currentPrompt, metaPrompt, nil)
+	raw, err := s.aiService.ApplyCustomPrompt(ctx, metaPrompt, nil)
 	if err != nil {
 		return nil, fmt.Errorf("LLM refinement failed: %w", err)
 	}
@@ -79,7 +79,7 @@ func (s *PromptGeneratorServiceImpl) GenerateFromIntentStream(ctx context.Contex
 	metaPrompt := s.buildGenerationPrompt(intent, opts)
 
 	// AIService validates content non-empty but only uses prompt; pass intent as content.
-	raw, err := s.aiService.ApplyCustomPromptStream(ctx, intent, metaPrompt, nil, func(token string) {
+	raw, err := s.aiService.ApplyCustomPromptStream(ctx, metaPrompt, nil, func(token string) {
 		if onToken != nil {
 			onToken(token)
 		}
@@ -110,7 +110,7 @@ func (s *PromptGeneratorServiceImpl) RefinePromptStream(ctx context.Context, cur
 	metaPrompt := s.buildRefinementPrompt(currentPrompt, refinement, opts)
 
 	// AIService validates content non-empty but only uses prompt; pass currentPrompt as content.
-	raw, err := s.aiService.ApplyCustomPromptStream(ctx, currentPrompt, metaPrompt, nil, func(token string) {
+	raw, err := s.aiService.ApplyCustomPromptStream(ctx, metaPrompt, nil, func(token string) {
 		if onToken != nil {
 			onToken(token)
 		}

--- a/internal/services/prompt_generator_service_test.go
+++ b/internal/services/prompt_generator_service_test.go
@@ -47,13 +47,13 @@ func (m *mockAIService) FormatContent(ctx context.Context, content string, optio
 	return args.String(0), args.Error(1)
 }
 
-func (m *mockAIService) ApplyCustomPrompt(ctx context.Context, content string, prompt string, variables map[string]string) (string, error) {
-	args := m.Called(ctx, content, prompt, variables)
+func (m *mockAIService) ApplyCustomPrompt(ctx context.Context, prompt string, variables map[string]string) (string, error) {
+	args := m.Called(ctx, prompt, variables)
 	return args.String(0), args.Error(1)
 }
 
-func (m *mockAIService) ApplyCustomPromptStream(ctx context.Context, content string, prompt string, variables map[string]string, onToken func(string)) (string, error) {
-	args := m.Called(ctx, content, prompt, variables, onToken)
+func (m *mockAIService) ApplyCustomPromptStream(ctx context.Context, prompt string, variables map[string]string, onToken func(string)) (string, error) {
+	args := m.Called(ctx, prompt, variables, onToken)
 	return args.String(0), args.Error(1)
 }
 
@@ -139,7 +139,6 @@ __MODE__: single`
 	mockAI.On("ApplyCustomPrompt",
 		mock.Anything,
 		mock.AnythingOfType("string"),
-		mock.AnythingOfType("string"),
 		mock.Anything,
 	).Return(canned, nil)
 
@@ -160,7 +159,6 @@ func TestPromptGeneratorServiceImpl_GenerateFromIntent_AIServiceFailure(t *testi
 
 	mockAI.On("ApplyCustomPrompt",
 		mock.Anything,
-		mock.AnythingOfType("string"),
 		mock.AnythingOfType("string"),
 		mock.Anything,
 	).Return("", assert.AnError)
@@ -185,7 +183,6 @@ __MODE__: single`
 
 	mockAI.On("ApplyCustomPrompt",
 		mock.Anything,
-		mock.AnythingOfType("string"),
 		mock.AnythingOfType("string"),
 		mock.Anything,
 	).Return(refined, nil)
@@ -224,12 +221,11 @@ __MODE__: single`
 	mockAI.On("ApplyCustomPromptStream",
 		mock.Anything,
 		mock.AnythingOfType("string"),
-		mock.AnythingOfType("string"),
 		mock.Anything,
 		mock.AnythingOfType("func(string)"),
 	).Run(func(args mock.Arguments) {
 		// Invoke the streaming callback with chunks.
-		cb := args.Get(4).(func(string))
+		cb := args.Get(3).(func(string))
 		cb("Analyze ")
 		cb("{{body}}.\n\n")
 		cb("__NAME__: simple\n")
@@ -269,11 +265,10 @@ __MODE__: single`
 	mockAI.On("ApplyCustomPromptStream",
 		mock.Anything,
 		mock.AnythingOfType("string"),
-		mock.AnythingOfType("string"),
 		mock.Anything,
 		mock.AnythingOfType("func(string)"),
 	).Run(func(args mock.Arguments) {
-		cb := args.Get(4).(func(string))
+		cb := args.Get(3).(func(string))
 		cb("Analyze ")
 		cb("{{body}}. Output JSON.\n\n")
 		cb("__NAME__: refined-json\n")

--- a/internal/services/prompt_service.go
+++ b/internal/services/prompt_service.go
@@ -77,7 +77,7 @@ func (s *PromptServiceImpl) ApplyPrompt(ctx context.Context, messageContent stri
 	}
 
 	// Apply the prompt using the AI service
-	result, err := s.aiService.ApplyCustomPrompt(ctx, messageContent, prompt, variables)
+	result, err := s.aiService.ApplyCustomPrompt(ctx, prompt, variables)
 	if err != nil {
 		return nil, fmt.Errorf("failed to apply prompt: %w", err)
 	}
@@ -123,7 +123,7 @@ func (s *PromptServiceImpl) ApplyPromptStream(ctx context.Context, messageConten
 	}
 
 	// Apply the prompt using the AI service with streaming
-	result, err := s.aiService.ApplyCustomPromptStream(ctx, messageContent, prompt, variables, onToken)
+	result, err := s.aiService.ApplyCustomPromptStream(ctx, prompt, variables, onToken)
 	if err != nil {
 		return nil, fmt.Errorf("failed to apply prompt: %w", err)
 	}

--- a/internal/services/slack_service.go
+++ b/internal/services/slack_service.go
@@ -150,7 +150,7 @@ func (s *SlackServiceImpl) formatSummaryMessage(ctx context.Context, headers map
 			promptWithVars = strings.ReplaceAll(promptWithVars, placeholder, value)
 		}
 
-		summary, err := s.aiService.ApplyCustomPrompt(ctx, body, promptWithVars, variables)
+		summary, err := s.aiService.ApplyCustomPrompt(ctx, promptWithVars, variables)
 		if err != nil {
 			// Fallback to first few lines if AI fails
 			summary = s.truncateText(body, 200)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1412,6 +1412,11 @@ func (a *App) GetPromptGeneratorService() services.PromptGeneratorService {
 	return a.promptGeneratorService
 }
 
+// GetBulkPromptService returns the bulk prompt service or nil if not initialized.
+func (a *App) GetBulkPromptService() *services.BulkPromptServiceImpl {
+	return a.bulkPromptService
+}
+
 // GetAccountService returns the account service instance
 func (a *App) GetAccountService() services.AccountService {
 	return a.accountService

--- a/internal/tui/prompt_configurator.go
+++ b/internal/tui/prompt_configurator.go
@@ -506,7 +506,7 @@ func (a *App) applyEphemeralPromptToMessage(messageID string, promptText string,
 	}()
 
 	var b strings.Builder
-	result, err := aiService.ApplyCustomPromptStream(ctx, content, finalPrompt, nil, func(token string) {
+	result, err := aiService.ApplyCustomPromptStream(ctx, finalPrompt, nil, func(token string) {
 		select {
 		case <-ctx.Done():
 			return
@@ -613,7 +613,7 @@ func (a *App) applyEphemeralPromptToBulk(messageIDs []string, promptText string,
 	}()
 
 	var b strings.Builder
-	result, err := aiService.ApplyCustomPromptStream(ctx, combined.String(), finalPrompt, nil, func(token string) {
+	result, err := aiService.ApplyCustomPromptStream(ctx, finalPrompt, nil, func(token string) {
 		select {
 		case <-ctx.Done():
 			return

--- a/internal/tui/prompt_configurator.go
+++ b/internal/tui/prompt_configurator.go
@@ -550,9 +550,9 @@ func (a *App) applyEphemeralPromptToMessage(messageID string, promptText string,
 // The configurator is already closed by applyConfiguratorPrompt (UI thread) before this
 // runs in a goroutine; this function only touches the AI panel via QueueUpdateDraw/streaming.
 func (a *App) applyEphemeralPromptToBulk(messageIDs []string, promptText string, displayName string) {
-	_, aiService, _, _, repository, _, _, _, _, _, _, _ := a.GetServices()
-	if aiService == nil || repository == nil {
-		a.GetErrorHandler().ShowError(a.ctx, "AI or repository service not available")
+	bulkSvc := a.GetBulkPromptService()
+	if bulkSvc == nil {
+		a.GetErrorHandler().ShowError(a.ctx, "Bulk prompt service not available")
 		return
 	}
 
@@ -560,33 +560,6 @@ func (a *App) applyEphemeralPromptToBulk(messageIDs []string, promptText string,
 	if name == "" {
 		name = "Custom Bulk Prompt"
 	}
-
-	// Build combined content from messages using PlainText (repository.GetMessage calls GetMessageWithContent).
-	var combined strings.Builder
-	combined.WriteString("---START EMAILS---\n")
-	for i, id := range messageIDs {
-		msg, err := repository.GetMessage(a.ctx, id)
-		if err != nil || msg == nil {
-			continue
-		}
-		fmt.Fprintf(&combined, "---START EMAIL %d---\n", i+1)
-		content := msg.PlainText
-		if len([]rune(content)) > 2000 {
-			content = string([]rune(content)[:2000])
-		}
-		if content != "" {
-			combined.WriteString(content)
-		} else if msg.Snippet != "" {
-			combined.WriteString(msg.Snippet)
-		}
-		fmt.Fprintf(&combined, "\n---END EMAIL %d---\n", i+1)
-	}
-	combined.WriteString("---END OF EMAILS---\n")
-
-	// Substitute placeholders.
-	finalPrompt := promptText
-	finalPrompt = strings.ReplaceAll(finalPrompt, "{{messages}}", combined.String())
-	finalPrompt = strings.ReplaceAll(finalPrompt, "{{body}}", combined.String())
 
 	a.QueueUpdateDraw(func() {
 		if !a.aiSummaryVisible {
@@ -613,7 +586,9 @@ func (a *App) applyEphemeralPromptToBulk(messageIDs []string, promptText string,
 	}()
 
 	var b strings.Builder
-	result, err := aiService.ApplyCustomPromptStream(ctx, finalPrompt, nil, func(token string) {
+	// Route through BulkPromptService so ephemeral applies use the same content
+	// extraction + cleaning + combination as saved-prompt bulk applies (issue #44).
+	result, err := bulkSvc.ApplyEphemeralBulkPromptStream(ctx, messageIDs, promptText, nil, func(token string) {
 		select {
 		case <-ctx.Done():
 			return


### PR DESCRIPTION
## Summary

Resolves the two tech-debt issues found during the Prompt Configurator review.

### Fixes #43 — remove the zombie `content` param

`AIService.ApplyCustomPrompt[Stream]` accepted a `content string` that was validated non-empty but **never used** — only the `prompt` was sent to the provider. Every caller already substitutes email content/variables into a self-contained prompt before calling, so `content` was pure dead weight whose non-empty validation caused spurious failures and masked placeholder-substitution bugs in the configurator.

Removed the parameter from the interface, both `AIServiceImpl` methods (and their validation), the regenerated mock, the local test mock, and all 10 call sites (slack, bulk-prompt, prompt, prompt-generator services + the configurator). No behavior change — `content` was never used.

### Fixes #44 — ephemeral bulk apply now matches the saved-prompt path

The configurator's ephemeral bulk apply hand-rolled the email envelope + truncation, skipping the `cleanEmailContent` heuristics used by `BulkPromptService.combineMessageContents`. So the same prompt + same messages produced different (dirtier) LLM input depending on the path.

Added `BulkPromptService.ApplyEphemeralBulkPromptStream` (reuses extract + clean + combine + build) and routed the configurator through it via a new `App.GetBulkPromptService` accessor. Also made `buildBulkPrompt` append the combined content when the prompt has no `{{messages}}`/`{{body}}` placeholder, so prompts that forget the placeholder still receive the emails (benefits both bulk paths) — found and fixed via E2E testing where an LLM-generated prompt omitted the placeholder.

## Verification

- `make pre-commit-check` passes (fmt + vet + golangci-lint 0 issues + tests).
- E2E verified with real LLM (Ollama `qwen2.5:7b`): single + bulk generate→apply both produce correct, real summaries; bulk apply now goes through `BulkPromptService` and the placeholder fallback works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
