### PR TITLE
chore: stop tracking .claude/scheduled_tasks.lock

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"5a98f660-5fe8-4661-90f9-cc7e2fd1f50a","pid":1861168,"procStart":"336443244","acquiredAt":1780480724606}

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ config.local.json
 
 # Github inspiration references
 reference/
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
Removes the runtime lock file `.claude/scheduled_tasks.lock` that was accidentally committed via `git add -A` in the #43 work, and adds it to `.gitignore`. It's a session-runtime file, not source.