### PR TITLE
chore: wire graphify knowledge-graph integration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,26 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CMD=$(python3 -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',d).get('command',''))\" 2>/dev/null || true); case \"$CMD\" in *grep*|*rg\\ *|*ripgrep*|*find\\ *|*fd\\ *|*ack\\ *|*ag\\ *)   [ -f graphify-out/graph.json ] &&   echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"MANDATORY: graphify-out/graph.json exists. You MUST run `graphify query \\\"<question>\\\"` before grepping raw files. Only grep after graphify has oriented you, or to modify/debug specific lines.\"}}'   || true ;; esac"
+          }
+        ]
+      },
+      {
+        "matcher": "Read|Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "HIT=$(python3 -c \"import json,sys;d=json.load(sys.stdin);t=d.get('tool_input',d);s=(str(t.get('file_path') or '')+' '+str(t.get('pattern') or '')+' '+str(t.get('path') or '')).lower().replace(chr(92),'/');exts=('.py','.js','.ts','.tsx','.jsx','.go','.rs','.java','.rb','.c','.h','.cpp','.hpp','.cc','.cs','.kt','.swift','.php','.scala','.lua','.sh','.md','.rst','.txt','.mdx');sys.stdout.write('1' if 'graphify-out/' not in s and any(e in s for e in exts) else '')\" 2>/dev/null || true); if [ \"$HIT\" = 1 ] && [ -f graphify-out/graph.json ]; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"MANDATORY: graphify-out/graph.json exists. You MUST run graphify before reading source files. Use: `graphify query \\\"<question>\\\"` (scoped subgraph), `graphify explain \\\"<concept>\\\"`, or `graphify path \\\"<A>\\\" \\\"<B>\\\"`. Only read raw files after graphify has oriented you, or to modify/debug specific lines. This rule applies to subagents too \u2014 include it in every subagent prompt involving code exploration.\"}}'; fi || true"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ reference/
 
 # Local session handoff notes (/remember skill)
 .remember/
+
+# graphify knowledge graph (regenerated via /graphify or `graphify update`)
+graphify-out/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,3 +337,13 @@ For detailed information, see:
 ---
 
 **Remember**: This architecture ensures maintainable, testable, and robust code. Follow these patterns consistently for high-quality development.
+
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+Rules:
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1040,6 +1040,8 @@ Controls the **Inbox Action Plan** feature (shortcut `P` / command `:action-plan
 
 The shortcut is configurable via `keys.action_plan` (default `"P"`).
 
+The analyzer may also assign a **`summarize`** action to a category; press your summarize key (`keys.summarize`, default `y`) on that category to get a combined AI digest of its emails in an in-place panel (Esc to return).
+
 **Rules and interests:** with `:plan rules` (or `Ctrl+R` inside the Action Plan) you can save free-text **action rules** ("archive everything from GitHub") *and* **interests** ("I'm interested in AI"). The analyzer treats interests as relevance signals: emails matching them are surfaced (priority "high" + a note in the category description) instead of being buried in a bulk action.
 
 ### Auto-Refresh Configuration

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1040,6 +1040,8 @@ Controls the **Inbox Action Plan** feature (shortcut `P` / command `:action-plan
 
 The shortcut is configurable via `keys.action_plan` (default `"P"`).
 
+**Rules and interests:** with `:plan rules` (or `Ctrl+R` inside the Action Plan) you can save free-text **action rules** ("archive everything from GitHub") *and* **interests** ("I'm interested in AI"). The analyzer treats interests as relevance signals: emails matching them are surfaced (priority "high" + a note in the category description) instead of being buried in a bulk action.
+
 ### Auto-Refresh Configuration
 
 Opt-in background polling that detects new inbox mail. While you are viewing the plain inbox and nothing is open (no picker, search, bulk selection, or composer), new mail is **prepended in place** without moving your cursor. Otherwise a pending counter `📬 N` appears in the status bar and you load it with `R` when ready. The status bar shows `⟳` while enabled. Only the plain inbox is polled (search/folder/thread views idle the ticker).

--- a/docs/superpowers/plans/2026-06-13-analyzer-existing-labels.md
+++ b/docs/superpowers/plans/2026-06-13-analyzer-existing-labels.md
@@ -1,0 +1,236 @@
+# Analyzer Existing-Labels Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Feed the analyzer the user's existing (user-created) labels so it prefers an exact match for the `label` action instead of inventing labels.
+
+**Architecture:** A new `AvailableLabels` option + a `prependAvailableLabels` prompt block (mirroring `prependUserRules`), applied in `Analyze` and `BuildPromptPreview`. The TUI populates it from `ListLabels` filtered to user labels. Dispatch unchanged.
+
+**Tech Stack:** Go, GizTUI analyzer prompt + Label service + Action Plan TUI.
+
+Spec: `docs/superpowers/specs/2026-06-13-analyzer-existing-labels-design.md`
+
+---
+
+### Task 1: `AvailableLabels` option + `prependAvailableLabels` + prompt wiring
+
+**Files:**
+- Modify: `internal/services/interfaces.go` (`InboxAnalyzerOptions`)
+- Modify: `internal/services/inbox_analyzer_service.go` (`prependAvailableLabels`, `Analyze`, `BuildPromptPreview`)
+- Test: `internal/services/inbox_analyzer_service_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/services/inbox_analyzer_service_test.go`:
+
+```go
+func TestPrependAvailableLabels(t *testing.T) {
+	got := prependAvailableLabels("BASEPROMPT", []string{"work", "receipts"})
+	if !strings.Contains(got, "## Existing labels") {
+		t.Fatalf("expected labels heading, got:\n%s", got)
+	}
+	if !strings.Contains(got, "work") || !strings.Contains(got, "receipts") {
+		t.Fatalf("expected label names, got:\n%s", got)
+	}
+	if !strings.Contains(got, "PREFER an exact name") {
+		t.Fatalf("expected the prefer-existing instruction, got:\n%s", got)
+	}
+	if !strings.Contains(got, "BASEPROMPT") {
+		t.Fatalf("expected base prompt retained, got:\n%s", got)
+	}
+	if prependAvailableLabels("BASEPROMPT", nil) != "BASEPROMPT" {
+		t.Fatal("empty labels must return the base prompt unchanged")
+	}
+}
+
+func TestBuildPromptPreview_Labels(t *testing.T) {
+	s := NewInboxAnalyzerService(nil)
+	out := s.BuildPromptPreview(InboxAnalyzerOptions{AvailableLabels: []string{"work"}})
+	if !strings.Contains(out, "## Existing labels") || !strings.Contains(out, "work") {
+		t.Fatalf("preview should include the labels block, got:\n%s", out)
+	}
+	out = s.BuildPromptPreview(InboxAnalyzerOptions{})
+	if strings.Contains(out, "## Existing labels") {
+		t.Fatalf("no labels → no labels block, got:\n%s", out)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/services/ -run 'TestPrependAvailableLabels|TestBuildPromptPreview_Labels' -v`
+Expected: FAIL — `prependAvailableLabels` undefined / `AvailableLabels` field missing.
+
+- [ ] **Step 3: Add the option field**
+
+In `internal/services/interfaces.go`, add to `InboxAnalyzerOptions`:
+
+```go
+	AvailableLabels  []string // existing user-label names; analyzer prefers these for the "label" action
+```
+
+- [ ] **Step 4: Add `prependAvailableLabels`**
+
+In `internal/services/inbox_analyzer_service.go`, add (near `prependUserRules`):
+
+```go
+// prependAvailableLabels prepends an "## Existing labels" block when labels are present, telling
+// the model to prefer an exact existing label for the "label" action. Empty → prompt unchanged.
+func prependAvailableLabels(promptText string, labels []string) string {
+	clean := make([]string, 0, len(labels))
+	for _, l := range labels {
+		if strings.TrimSpace(l) != "" {
+			clean = append(clean, strings.TrimSpace(l))
+		}
+	}
+	if len(clean) == 0 {
+		return promptText
+	}
+	header := "## Existing labels\n" +
+		"These labels already exist in the mailbox: " + strings.Join(clean, ", ") + "\n" +
+		"For the \"label\" action, PREFER an exact name from this list when one fits. Only invent a " +
+		"NEW label when none fits; if you do, keep it short kebab-case and note \"(new)\" in the " +
+		"category description.\n\n"
+	return header + promptText
+}
+```
+
+- [ ] **Step 5: Apply it in `Analyze` and `BuildPromptPreview`**
+
+In `internal/services/inbox_analyzer_service.go`, in `Analyze`, after the existing
+`promptText = prependUserRules(promptText, opts.UserRules)` line, add:
+
+```go
+	promptText = prependAvailableLabels(promptText, opts.AvailableLabels)
+```
+
+In `BuildPromptPreview`, change:
+```go
+	return prependUserRules(base, opts.UserRules)
+```
+to:
+```go
+	withRules := prependUserRules(base, opts.UserRules)
+	return prependAvailableLabels(withRules, opts.AvailableLabels)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test ./internal/services/ -run 'TestPrependAvailableLabels|TestBuildPromptPreview|TestPrependUserRules' -v`
+Expected: PASS (existing prompt tests unaffected).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/services/interfaces.go internal/services/inbox_analyzer_service.go internal/services/inbox_analyzer_service_test.go
+git commit -m "feat(analyzer): prefer existing user labels via prompt (AvailableLabels)"
+```
+
+---
+
+### Task 2: TUI populates AvailableLabels (user labels only)
+
+**Files:**
+- Modify: `internal/tui/action_plan.go` (new `userLabelNames` helper + analyze-flow opts)
+- Modify: `internal/tui/action_plan_prompt.go` (viewer opts)
+
+No unit test for the wiring (covered by service tests + build); the filter helper is simple.
+
+- [ ] **Step 1: Add the `userLabelNames` helper**
+
+In `internal/tui/action_plan.go`, add:
+
+```go
+// userLabelNames returns the names of the user's own labels (excluding Gmail system labels),
+// for feeding the analyzer so it prefers existing labels. Errors degrade to an empty slice.
+func (a *App) userLabelNames() []string {
+	_, _, labelService, _, _, _, _, _, _, _, _, _ := a.GetServices()
+	if labelService == nil {
+		return nil
+	}
+	labels, err := labelService.ListLabels(a.ctx)
+	if err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(labels))
+	for _, l := range labels {
+		if l != nil && l.Type == "user" {
+			out = append(out, l.Name)
+		}
+	}
+	return out
+}
+```
+
+- [ ] **Step 2: Populate it in the analyze flow**
+
+In `internal/tui/action_plan.go`, where the analyze goroutine builds the options (the line passing
+`services.InboxAnalyzerOptions{BatchSize: batchSize, MaxBatches: maxBatches, CustomPromptText: customPromptText, UserRules: userRules, BodyCharLimit: bodyCharLimit}`), capture the labels before
+the goroutine (alongside `userRules`):
+
+```go
+	availableLabels := a.userLabelNames()
+```
+
+and add `AvailableLabels: availableLabels` to that `InboxAnalyzerOptions` literal:
+
+```go
+			services.InboxAnalyzerOptions{BatchSize: batchSize, MaxBatches: maxBatches, CustomPromptText: customPromptText, UserRules: userRules, BodyCharLimit: bodyCharLimit, AvailableLabels: availableLabels},
+```
+
+(Compute `availableLabels` next to where `userRules` is gathered — outside the goroutine — so the
+ListLabels read isn't racing the analysis.)
+
+- [ ] **Step 3: Populate it in the prompt viewer**
+
+In `internal/tui/action_plan_prompt.go`, in the `opts := services.InboxAnalyzerOptions{...}` literal,
+add `AvailableLabels: a.userLabelNames()` so the `v` viewer matches what Analyze sends.
+
+- [ ] **Step 4: Build + tests**
+
+Run: `go build ./... && go test ./internal/services/ ./internal/tui/ 2>&1 | tail -3`
+Expected: build success; all `ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tui/action_plan.go internal/tui/action_plan_prompt.go
+git commit -m "feat(action-plan): feed existing user labels to the analyzer + prompt viewer"
+```
+
+---
+
+### Task 3: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Pre-commit gate**
+
+Run: `make pre-commit-check`
+Expected: fmt + vet + lint + essential tests pass.
+
+- [ ] **Step 2: Targeted + leak check**
+
+Run: `go test ./internal/services/ ./internal/tui/ ./test/helpers/ 2>&1 | tail -5`
+Expected: all `ok`.
+
+- [ ] **Step 3: Build**
+
+Run: `make build`
+Expected: success.
+
+(Live E2E — open the Action Plan, press `v`, confirm an "## Existing labels" block lists your real
+labels; run analysis and check `label` categories reuse existing names — deferred to user E2E.)
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** `AvailableLabels` option (Task 1), `prependAvailableLabels` + Analyze +
+  BuildPromptPreview (Task 1), TUI `userLabelNames` filtered to `Type=="user"` + analyze-flow +
+  viewer population (Task 2), verification (Task 3). All spec sections mapped. Dispatch unchanged
+  (per decision) — no task.
+- **Type consistency:** `AvailableLabels []string` on `InboxAnalyzerOptions`;
+  `prependAvailableLabels(promptText string, labels []string) string`; `userLabelNames() []string`
+  — match across tasks and call sites. `GetServices()` 12-tuple: `labelService` is the 3rd return.
+- **No placeholders:** every code step shows full code; commands have expected output.

--- a/docs/superpowers/plans/2026-06-13-analyzer-interests.md
+++ b/docs/superpowers/plans/2026-06-13-analyzer-interests.md
@@ -1,0 +1,279 @@
+# Analyzer Interests Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the analyzer treat saved free-text rules as interest/relevance signals (surfacing matching emails as priority "high"), relabel the rules UI so interests are discoverable, and fix the `:plan rules` focus bug.
+
+**Architecture:** A prompt reframe in `prependUserRules` (no schema/UI change). UI label tweaks in the rules manager. A synchronous focus fix using the existing `cmdFocusOverride` mechanism so the rules picker keeps focus after the command bar closes.
+
+**Tech Stack:** Go, GizTUI analyzer prompt + TUI command/focus handling.
+
+Spec: `docs/superpowers/specs/2026-06-13-analyzer-interests-design.md`
+
+---
+
+### Task 1: Prompt reframe — interests in `prependUserRules`
+
+**Files:**
+- Modify: `internal/services/inbox_analyzer_service.go` (`prependUserRules`)
+- Test: `internal/services/inbox_analyzer_service_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/services/inbox_analyzer_service_test.go`:
+
+```go
+func TestPrependUserRules_Interests(t *testing.T) {
+	got := prependUserRules("BASEPROMPT", []string{"interested in AI"})
+	if !strings.Contains(got, "## User preferences and interests") {
+		t.Fatalf("expected reframed heading, got:\n%s", got)
+	}
+	if !strings.Contains(got, "interest/relevance") {
+		t.Fatalf("expected the relevance instruction, got:\n%s", got)
+	}
+	if !strings.Contains(got, "interested in AI") || !strings.Contains(got, "BASEPROMPT") {
+		t.Fatalf("expected rule text + base prompt, got:\n%s", got)
+	}
+	// No rules → unchanged base prompt (no block).
+	if prependUserRules("BASEPROMPT", nil) != "BASEPROMPT" {
+		t.Fatal("empty rules must return the base prompt unchanged")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/services/ -run TestPrependUserRules_Interests -v`
+Expected: FAIL — heading is still "## User preferences (respect these rules)" / no "interest/relevance" string.
+
+- [ ] **Step 3: Reframe `prependUserRules`**
+
+In `internal/services/inbox_analyzer_service.go`, replace the final `return` of `prependUserRules`:
+
+```go
+	return "## User preferences (respect these rules)\n" + strings.Join(clean, "\n") + "\n\n" + promptText
+```
+
+with:
+
+```go
+	header := "## User preferences and interests\n" +
+		"Treat the following as BOTH action rules to respect AND interest/relevance signals. " +
+		"When an email matches a stated interest, do NOT bury it in a bulk archive/trash group: " +
+		"keep it visible, set that category's priority to \"high\", and note the matched interest " +
+		"in the category description.\n"
+	return header + strings.Join(clean, "\n") + "\n\n" + promptText
+```
+
+- [ ] **Step 4: Run tests to verify they pass (and existing ones still pass)**
+
+Run: `go test ./internal/services/ -run 'TestPrependUserRules|TestBuildPromptPreview|TestAnalyze' -v`
+Expected: PASS. (Existing assertions use `Contains(..., "## User preferences")`, which still matches the new heading.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/services/inbox_analyzer_service.go internal/services/inbox_analyzer_service_test.go
+git commit -m "feat(analyzer): treat saved rules as interest/relevance signals (prompt reframe)"
+```
+
+---
+
+### Task 2: Fix `:plan rules` focus (cmdFocusOverride="keep")
+
+**Files:**
+- Modify: `internal/tui/keys.go` (`restoreFocusAfterModal`, ~line 1630)
+- Modify: `internal/tui/action_plan_rules.go` (`openAnalyzerRulesManager`)
+- Test: `internal/tui/action_plan_rules_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/tui/action_plan_rules_test.go`:
+
+```go
+func TestAnalyzerRulesPickerSetsFocusKeepOverride(t *testing.T) {
+	a := newRulesTestApp()
+	a.openAnalyzerRulesManager()
+	if a.cmdFocusOverride != "keep" {
+		t.Fatalf("expected cmdFocusOverride=keep so the command bar teardown won't steal focus, got %q", a.cmdFocusOverride)
+	}
+}
+
+func TestRestoreFocusAfterModal_Keep(t *testing.T) {
+	a := newRulesTestApp()
+	a.currentFocus = "analyzer_rules"
+	a.cmdFocusOverride = "keep"
+	a.restoreFocusAfterModal()
+	if a.currentFocus != "analyzer_rules" {
+		t.Fatalf("keep override must not re-focus the list, got %q", a.currentFocus)
+	}
+	if a.cmdFocusOverride != "" {
+		t.Fatalf("override should be consumed, got %q", a.cmdFocusOverride)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/tui/ -run 'TestAnalyzerRulesPickerSetsFocusKeepOverride|TestRestoreFocusAfterModal_Keep' -v`
+Expected: FAIL — `openAnalyzerRulesManager` doesn't set the override yet; `restoreFocusAfterModal` has no "keep" case so it sets `currentFocus="list"`.
+
+- [ ] **Step 3: Add the "keep" case in `restoreFocusAfterModal`**
+
+In `internal/tui/keys.go`, inside `restoreFocusAfterModal`, the existing `switch override { ... }` (within the `if a.cmdFocusOverride != ""` block, which already clears the override) — add a case:
+
+```go
+		case "keep":
+			// A picker/command already set focus; leave it as-is.
+			return
+```
+
+- [ ] **Step 4: Set the override in `openAnalyzerRulesManager`**
+
+In `internal/tui/action_plan_rules.go`, at the end of `openAnalyzerRulesManager`, right after `a.SetFocus(list)` / `a.currentFocus = "analyzer_rules"`, add:
+
+```go
+	// :plan rules runs during command execution; hideCommandBar()'s restoreFocusAfterModal()
+	// would otherwise re-focus the message list afterward. "keep" tells it to leave our focus.
+	a.cmdFocusOverride = "keep"
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/tui/ -run 'TestAnalyzerRulesPicker|TestRestoreFocusAfterModal_Keep' -v`
+Expected: PASS (including the existing `TestAnalyzerRulesPickerSwap`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/tui/keys.go internal/tui/action_plan_rules.go internal/tui/action_plan_rules_test.go
+git commit -m "fix(tui): :plan rules keeps focus on the picker (cmdFocusOverride=keep)"
+```
+
+---
+
+### Task 3: Relabel the rules UI for interests
+
+**Files:**
+- Modify: `internal/tui/action_plan_rules.go` (3 label strings)
+
+No unit test (static label strings; build covers it).
+
+- [ ] **Step 1: Update the three labels**
+
+In `internal/tui/action_plan_rules.go`:
+
+Manager title:
+```go
+	container.SetTitle(" 🧠 Analyzer rules ")
+```
+→
+```go
+	container.SetTitle(" 🧠 Analyzer rules & interests ")
+```
+
+Add-rule input label:
+```go
+		input := tview.NewInputField().SetLabel(" New rule: ").SetFieldWidth(0)
+```
+→
+```go
+		input := tview.NewInputField().SetLabel(" Rule or interest: ").SetFieldWidth(0)
+```
+
+Ctrl+R remember panel title:
+```go
+	state.container.SetTitle(" 🧠 Remember preference ")
+```
+→
+```go
+	state.container.SetTitle(" 🧠 Remember rule or interest ")
+```
+
+- [ ] **Step 2: Build**
+
+Run: `go build ./...`
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/tui/action_plan_rules.go
+git commit -m "feat(tui): relabel rules UI to surface interests (discoverability)"
+```
+
+---
+
+### Task 4: Docs — `:help` + CONFIGURATION.md (Definition of Done)
+
+**Files:**
+- Modify: `internal/tui/app.go` (`generateHelpText` — the `:action-plan` help line)
+- Modify: `docs/CONFIGURATION.md`
+
+- [ ] **Step 1: Update the in-app help**
+
+In `internal/tui/app.go` `generateHelpText`, find the action-plan command line:
+```go
+	fmt.Fprintf(&help, "    %-18s 🧠  Open inbox Action Plan (alias :plan, :ap)\n", ":action-plan")
+```
+and add a line after it:
+```go
+	fmt.Fprintf(&help, "    %-18s 🧠  Manage analyzer rules/interests (e.g. 'interested in AI')\n", ":plan rules")
+```
+
+- [ ] **Step 2: Document in CONFIGURATION.md**
+
+In `docs/CONFIGURATION.md`, in the analyzer section (near the `inbox_analyzer` table / the `:plan rules` mention), add:
+
+```markdown
+**Rules and interests:** with `:plan rules` (or `Ctrl+R` inside the Action Plan) you can save
+free-text **action rules** ("archive everything from GitHub") *and* **interests** ("I'm interested
+in AI"). The analyzer treats interests as relevance signals: emails matching them are surfaced
+(priority "high" + a note in the category description) instead of being buried in a bulk action.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/tui/app.go docs/CONFIGURATION.md
+git commit -m "docs: document analyzer rules/interests (help + config)"
+```
+
+---
+
+### Task 5: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Pre-commit gate**
+
+Run: `make pre-commit-check`
+Expected: fmt + vet + lint + essential tests pass.
+
+- [ ] **Step 2: Targeted + full suite**
+
+Run: `go test ./internal/services/ ./internal/tui/ 2>&1 | tail -4`
+Expected: all `ok`.
+Run: `go test ./test/helpers/ 2>&1 | tail -2`
+Expected: `ok` (no leaked-goroutine regression — Task 2's fix is synchronous, no QueueUpdateDraw).
+
+- [ ] **Step 3: Build**
+
+Run: `make build`
+Expected: success.
+
+(Live E2E — `:plan rules` now grabs focus; add an interest like "interested in AI"; re-run the Action Plan and check matching emails get HIGH priority + a note — deferred to the user's E2E sweep.)
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** prompt reframe (Task 1), focus fix via cmdFocusOverride="keep" (Task 2), UI
+  relabel (Task 3), docs/`:help` (Task 4), verification incl. leak check (Task 5). All spec sections
+  mapped. Existing `prependUserRules`/`BuildPromptPreview` tests stay green (Contains-prefix match).
+- **Type consistency:** `cmdFocusOverride` string with value `"keep"` matches between
+  `openAnalyzerRulesManager` (set) and `restoreFocusAfterModal` (case). `prependUserRules` signature
+  unchanged.
+- **No placeholders:** every code step shows full code; commands have expected output.
+- **Leak-safety:** Task 2's fix is synchronous (no `QueueUpdateDraw`), so it cannot reintroduce the
+  goroutine-leak class that the config-notice fix addressed.

--- a/docs/superpowers/plans/2026-06-13-analyzer-summarize-action.md
+++ b/docs/superpowers/plans/2026-06-13-analyzer-summarize-action.md
@@ -1,0 +1,479 @@
+# Analyzer "summarize" Action Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `summarize` analyzer action; pressing the summarize key on a category generates a single combined AI digest of its emails, shown in an in-place Action Plan panel (Markdown), Esc to return.
+
+**Architecture:** Prompt gains a `summarize` action; `actionVerbLabel`/`actionRuleVerbShort`/`actionKeyHint` learn it (mapped to the `y` key). A new `dispatchActionPlanSummarize` body-swaps the tree for a TextView, fetches bodies, calls `AIService.GenerateSummary` (non-streaming), and renders the digest via `renderPromptResult` + one `QueueUpdateDraw`.
+
+**Tech Stack:** Go, GizTUI analyzer prompt + Action Plan TUI + AIService.
+
+Spec: `docs/superpowers/specs/2026-06-13-analyzer-summarize-action-design.md`
+
+---
+
+### Task 1: Prompt action + action metadata
+
+**Files:**
+- Modify: `internal/services/inbox_analyzer_prompt.txt`
+- Modify: `internal/tui/action_plan.go` (`actionVerbLabel`, `actionRuleVerbShort`, `actionKeyHint`)
+- Test: `internal/tui/action_plan_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/tui/action_plan_test.go`:
+
+```go
+func TestActionVerb_Summarize(t *testing.T) {
+	if got := actionVerbLabel("summarize"); got != "summarize" {
+		t.Fatalf("actionVerbLabel(summarize)=%q", got)
+	}
+	if got := actionRuleVerbShort("summarize"); got != "digest" {
+		t.Fatalf("actionRuleVerbShort(summarize)=%q", got)
+	}
+	a := &App{}
+	a.Keys.Summarize = "y"
+	if got := a.actionKeyHint("summarize"); got != "y" {
+		t.Fatalf("actionKeyHint(summarize)=%q, want y", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/tui/ -run TestActionVerb_Summarize -v`
+Expected: FAIL — the three funcs return defaults for "summarize".
+
+- [ ] **Step 3: Add the action to the prompt**
+
+In `internal/services/inbox_analyzer_prompt.txt`, in the action set list (after the `"none"` line), add:
+
+```
+  "summarize" — worth a quick AI digest; not full reading, not discarding
+```
+
+- [ ] **Step 4: Teach the three metadata functions**
+
+In `internal/tui/action_plan.go`:
+
+`actionVerbLabel` — add a case (before its `default`):
+```go
+	case "summarize":
+		return "summarize"
+```
+
+`actionRuleVerbShort` — add a case (before its `default`):
+```go
+	case "summarize":
+		return "digest"
+```
+
+`actionKeyHint` — add a case (before its `default`):
+```go
+	case "summarize":
+		return a.Keys.Summarize
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test ./internal/tui/ -run TestActionVerb_Summarize -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/services/inbox_analyzer_prompt.txt internal/tui/action_plan.go internal/tui/action_plan_test.go
+git commit -m "feat(analyzer): add 'summarize' action + footer metadata"
+```
+
+---
+
+### Task 2: `buildSummarizeInput` pure helper
+
+**Files:**
+- Create: `internal/tui/action_plan_summarize.go`
+- Test: `internal/tui/action_plan_summarize_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/tui/action_plan_summarize_test.go`:
+
+```go
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	gmailapi "google.golang.org/api/gmail/v1"
+)
+
+func TestBuildSummarizeInput(t *testing.T) {
+	meta := map[string]*gmailapi.Message{
+		"m1": {Id: "m1", Snippet: "snip1", Payload: &gmailapi.MessagePart{Headers: []*gmailapi.MessagePartHeader{
+			{Name: "Subject", Value: "Hello"}, {Name: "From", Value: "a@x.com"},
+		}}},
+		"m2": {Id: "m2", Snippet: "snip2", Payload: &gmailapi.MessagePart{Headers: []*gmailapi.MessagePartHeader{
+			{Name: "Subject", Value: "World"}, {Name: "From", Value: "b@x.com"},
+		}}},
+	}
+	bodies := map[string]string{"m1": "full body one"}
+
+	out := buildSummarizeInput([]string{"m1", "m2"}, bodies, meta, 1000)
+
+	if !strings.Contains(out, "Hello") || !strings.Contains(out, "a@x.com") {
+		t.Fatalf("missing m1 subject/from:\n%s", out)
+	}
+	if !strings.Contains(out, "full body one") {
+		t.Fatalf("m1 should use its body:\n%s", out)
+	}
+	if !strings.Contains(out, "snip2") {
+		t.Fatalf("m2 has no body → should fall back to snippet:\n%s", out)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/tui/ -run TestBuildSummarizeInput -v`
+Expected: FAIL — `buildSummarizeInput` undefined.
+
+- [ ] **Step 3: Implement the helper (in the new file)**
+
+Create `internal/tui/action_plan_summarize.go`:
+
+```go
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	gmailapi "google.golang.org/api/gmail/v1"
+)
+
+// buildSummarizeInput renders the category's emails into a numbered blob for the AI digest:
+// "N. Subject: … | From: …\n   <body up to limit, or snippet if no body>". metaByID supplies
+// subject/from/snippet; bodies (id->plain text) supplies the body when available.
+func buildSummarizeInput(ids []string, bodies map[string]string, metaByID map[string]*gmailapi.Message, limit int) string {
+	var b strings.Builder
+	for i, id := range ids {
+		subject, from, snippet := "(unknown)", "", ""
+		if m := metaByID[id]; m != nil {
+			subject = extractHeaderValue(m, "Subject")
+			from = extractHeaderValue(m, "From")
+			snippet = m.Snippet
+		}
+		body := bodies[id]
+		if strings.TrimSpace(body) == "" {
+			body = snippet
+		}
+		fmt.Fprintf(&b, "%d. Subject: %s | From: %s\n   %s\n", i+1, subject, from, truncateForSummary(body, limit))
+	}
+	return b.String()
+}
+
+// truncateForSummary collapses whitespace and cuts to limit runes (limit <= 0 → no cut).
+func truncateForSummary(text string, limit int) string {
+	collapsed := strings.TrimSpace(strings.Join(strings.Fields(text), " "))
+	if limit <= 0 || len([]rune(collapsed)) <= limit {
+		return collapsed
+	}
+	return string([]rune(collapsed)[:limit])
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/tui/ -run TestBuildSummarizeInput -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tui/action_plan_summarize.go internal/tui/action_plan_summarize_test.go
+git commit -m "feat(action-plan): buildSummarizeInput digest-content helper"
+```
+
+---
+
+### Task 3: `dispatchActionPlanSummarize` + key wiring + sentinel
+
+**Files:**
+- Modify: `internal/tui/action_plan_summarize.go` (add the dispatch method)
+- Modify: `internal/tui/action_plan.go` (`actionPlanInputCapture` — `y` case)
+- Modify: `internal/tui/keys.go` (pass-through sentinel)
+- Test: `internal/tui/action_plan_summarize_test.go` (swap test + AIService stub)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/tui/action_plan_summarize_test.go`:
+
+```go
+import (
+	"context"
+
+	"github.com/ajramos/giztui/internal/services"
+	tcell "github.com/derailed/tcell/v2"
+	"github.com/derailed/tview"
+)
+
+type stubAISummary struct{}
+
+func (stubAISummary) GenerateSummary(ctx context.Context, content string, o services.SummaryOptions) (*services.SummaryResult, error) {
+	return &services.SummaryResult{Summary: "DIGEST RESULT"}, nil
+}
+func (stubAISummary) GenerateSummaryStream(ctx context.Context, content string, o services.SummaryOptions, onToken func(string)) (*services.SummaryResult, error) {
+	return &services.SummaryResult{Summary: "DIGEST RESULT"}, nil
+}
+func (stubAISummary) GenerateReply(ctx context.Context, content string, o services.ReplyOptions) (string, error) {
+	return "", nil
+}
+func (stubAISummary) SuggestLabels(ctx context.Context, content string, l []string) ([]string, error) {
+	return nil, nil
+}
+func (stubAISummary) FormatContent(ctx context.Context, content string, o services.FormatOptions) (string, error) {
+	return content, nil
+}
+func (stubAISummary) ApplyCustomPrompt(ctx context.Context, p string, v map[string]string) (string, error) {
+	return "", nil
+}
+func (stubAISummary) ApplyCustomPromptStream(ctx context.Context, p string, v map[string]string, onToken func(string)) (string, error) {
+	return "", nil
+}
+
+func TestActionPlanSummarizeSwap(t *testing.T) {
+	a := &App{Application: tview.NewApplication()}
+	a.ctx = context.Background()
+	a.aiService = stubAISummary{}
+	a.Config = nil // BodyCharLimit read defensively below
+	state := &actionPlanState{
+		plan: &services.ActionPlan{Categories: []services.ActionPlanCategory{
+			{Name: "News", Action: "summarize", MessageIDs: []string{"m1"}},
+		}},
+		selectedCategory: 0,
+		excluded:         map[string]bool{},
+		expanded:         map[int]bool{},
+		metaByID:         map[string]*gmailapi.Message{"m1": {Id: "m1", Snippet: "s"}},
+		footer:           tview.NewTextView(),
+	}
+	state.root = tview.NewTreeNode("")
+	state.tree = tview.NewTreeView().SetRoot(state.root)
+	state.container = tview.NewFlex().SetDirection(tview.FlexRow)
+	state.container.AddItem(state.tree, 0, 1, true)
+	state.container.AddItem(state.footer, 1, 0, false)
+	a.actionPlanState = state
+
+	a.dispatchActionPlanSummarize(state)
+	if a.currentFocus != "action_plan_summary" {
+		t.Fatalf("expected currentFocus=action_plan_summary, got %q", a.currentFocus)
+	}
+	if state.container.ItemAt(0) == state.tree {
+		t.Fatal("tree should be swapped out for the summary view")
+	}
+	view, ok := a.GetFocus().(*tview.TextView)
+	if !ok {
+		t.Fatalf("expected the summary TextView focused, got %T", a.GetFocus())
+	}
+	// Esc restores the tree.
+	if cap := view.GetInputCapture(); cap != nil {
+		cap(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone))
+	}
+	if a.currentFocus != "action_plan" {
+		t.Fatalf("after Esc, currentFocus should be action_plan, got %q", a.currentFocus)
+	}
+	if a.actionPlanState.container.ItemAt(0) != state.tree {
+		t.Fatal("after Esc the tree should be restored")
+	}
+}
+```
+
+Note: the test sets `a.Config = nil`; the dispatch must read `BodyCharLimit` defensively (see Step 2).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/tui/ -run TestActionPlanSummarizeSwap -v`
+Expected: FAIL — `dispatchActionPlanSummarize` undefined.
+
+- [ ] **Step 3: Implement `dispatchActionPlanSummarize`**
+
+Append to `internal/tui/action_plan_summarize.go` (and add the needed imports: `services`,
+`tcell`, `tview`, plus keep `fmt`/`strings`/`gmailapi`):
+
+```go
+// dispatchActionPlanSummarize body-swaps the tree for an in-place panel showing a combined AI
+// digest of the focused category's checked emails. Esc returns to the tree.
+func (a *App) dispatchActionPlanSummarize(state *actionPlanState) {
+	cat := a.currentActionPlanCategory(state)
+	if cat == nil {
+		return
+	}
+	ids := checkedIDs(cat.MessageIDs, state.excluded)
+	if len(ids) == 0 {
+		go a.GetErrorHandler().ShowWarning(a.ctx, "All emails in this category are excluded — nothing to summarize")
+		return
+	}
+
+	colors := a.GetComponentColors("ai")
+	view := tview.NewTextView().SetWrap(true).SetWordWrap(true)
+	view.SetBackgroundColor(colors.Background.Color())
+	view.SetTextColor(colors.Text.Color())
+	view.SetText(fmt.Sprintf("⏳ Summarizing %d email(s)…", len(ids)))
+
+	restore := func() {
+		state.container.RemoveItem(view)
+		state.container.RemoveItem(state.footer)
+		state.container.AddItem(state.tree, 0, 1, true)
+		state.container.AddItem(state.footer, 1, 0, false)
+		a.currentFocus = "action_plan"
+		a.SetFocus(state.tree)
+		a.renderActionPlanPanel(state)
+	}
+	view.SetInputCapture(func(ev *tcell.EventKey) *tcell.EventKey {
+		if ev.Key() == tcell.KeyEscape {
+			restore()
+			return nil
+		}
+		return ev
+	})
+
+	state.container.RemoveItem(state.tree)
+	state.container.RemoveItem(state.footer)
+	state.container.AddItem(view, 0, 1, true)
+	state.container.AddItem(state.footer, 1, 0, false)
+	state.container.SetTitle(fmt.Sprintf(" 📝 Digest of %q ", cat.Name))
+	state.footer.SetText(" ↑/↓ scroll  |  Esc to go back ")
+	a.currentFocus = "action_plan_summary"
+	a.SetFocus(view)
+
+	limit := 1000
+	if a.Config != nil {
+		limit = a.Config.InboxAnalyzer.BodyCharLimit
+	}
+	emailService, aiService, _, _, _, _, _, _, _, _, _, _ := a.GetServices()
+	go func() {
+		var bodies map[string]string
+		if emailService != nil {
+			bodies, _ = emailService.GetMessagePlainTexts(a.ctx, ids, 0)
+		}
+		blob := buildSummarizeInput(ids, bodies, state.metaByID, limit)
+		if aiService == nil {
+			a.QueueUpdateDraw(func() {
+				if a.actionPlanState == state {
+					view.SetText("⚠️ AI service not available")
+				}
+			})
+			return
+		}
+		res, err := aiService.GenerateSummary(a.ctx, blob, services.SummaryOptions{})
+		a.QueueUpdateDraw(func() {
+			if a.actionPlanState != state || a.ctx.Err() != nil {
+				return
+			}
+			if err != nil {
+				view.SetText(fmt.Sprintf("⚠️ Could not summarize: %v", err))
+				return
+			}
+			view.SetText(a.renderPromptResult(res.Summary))
+		})
+	}()
+}
+```
+
+In the test, `a.GetServices()` returns the stub `aiService` only if `a.aiService` is set — which
+the test does. `emailService` will be nil in the test (fine; `bodies` stays nil → snippet used).
+
+- [ ] **Step 4: Wire the `y` key in `actionPlanInputCapture`**
+
+In `internal/tui/action_plan.go`, in the `switch key { ... }` action block (with the
+`a.Keys.Archive` etc. cases), add:
+
+```go
+		case a.Keys.Summarize:
+			a.dispatchActionPlanSummarize(state)
+			return nil
+```
+
+- [ ] **Step 5: Add the keys.go sentinel**
+
+In `internal/tui/keys.go`, add `"action_plan_summary"` to the global pass-through line (next to
+`"action_plan_prompt"`):
+
+```go
+		if a.currentFocus == "prompt_preview" || a.currentFocus == "action_plan_move" ||
+			a.currentFocus == "analyzer_rules" || a.currentFocus == "analyzer_rules_add" ||
+			a.currentFocus == "action_plan_rule" || a.currentFocus == "action_plan_prompt" ||
+			a.currentFocus == "action_plan_summary" {
+			return event
+		}
+```
+
+- [ ] **Step 6: Run the test + build**
+
+Run: `go test ./internal/tui/ -run TestActionPlanSummarizeSwap -v && go build ./...`
+Expected: PASS, build success.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/tui/action_plan_summarize.go internal/tui/action_plan.go internal/tui/keys.go internal/tui/action_plan_summarize_test.go
+git commit -m "feat(action-plan): 'y' dispatches a combined AI digest of a category (in-place)"
+```
+
+---
+
+### Task 4: Docs + full verification
+
+**Files:**
+- Modify: `internal/tui/app.go` (`generateHelpText` footer note — optional), `docs/CONFIGURATION.md`
+
+- [ ] **Step 1: Document the summarize action**
+
+In `docs/CONFIGURATION.md` (analyzer section), add a sentence:
+
+```markdown
+The analyzer may also assign a **`summarize`** action to a category; press your summarize key
+(`keys.summarize`, default `y`) on that category to get a combined AI digest of its emails in an
+in-place panel (Esc to return).
+```
+
+- [ ] **Step 2: Pre-commit gate**
+
+Run: `make pre-commit-check`
+Expected: fmt + vet + lint + essential tests pass.
+
+- [ ] **Step 3: Suite + leak check**
+
+Run: `go test ./internal/services/ ./internal/tui/ ./test/helpers/ 2>&1 | tail -5`
+Expected: all `ok` (the single final `QueueUpdateDraw` is the standard safe pattern — no leak).
+
+- [ ] **Step 4: Build**
+
+Run: `make build`
+Expected: success.
+
+- [ ] **Step 5: Commit docs**
+
+```bash
+git add internal/tui/app.go docs/CONFIGURATION.md
+git commit -m "docs: document the analyzer summarize action"
+```
+
+(Live E2E — a `summarize` category, press `y`, see the ⏳ then the rendered digest; Esc returns —
+deferred to the user's E2E sweep.)
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** prompt action + metadata (Task 1), `buildSummarizeInput` (Task 2),
+  `dispatchActionPlanSummarize` body-swap + non-streaming `GenerateSummary` + final QueueUpdateDraw
+  render + `y` wiring + sentinel (Task 3), docs + verification incl. leak check (Task 4). All spec
+  sections mapped.
+- **Type consistency:** `buildSummarizeInput(ids []string, bodies map[string]string, metaByID map[string]*gmailapi.Message, limit int) string`,
+  `dispatchActionPlanSummarize(state *actionPlanState)`, `"action_plan_summary"` sentinel,
+  `GenerateSummary(ctx, content, SummaryOptions) (*SummaryResult, error)` (Summary field) — match
+  across tasks. `GetServices()` order: EmailService(1), AIService(2).
+- **No placeholders:** every code step shows full code.
+- **Leak-safety:** non-streaming; a single final `QueueUpdateDraw` guarded on
+  `a.actionPlanState == state` — the standard worker→UI pattern, not a per-token callback.

--- a/docs/superpowers/specs/2026-06-13-analyzer-existing-labels-design.md
+++ b/docs/superpowers/specs/2026-06-13-analyzer-existing-labels-design.md
@@ -1,0 +1,84 @@
+# Analyzer uses existing labels (idea A)
+
+**Date:** 2026-06-13
+**Status:** Approved (design)
+
+## Problem
+
+The analyzer's `label` action tells the LLM to "provide a short kebab-case label", so it invents
+label names that usually don't exist in the user's mailbox — and dispatch (`resolveOrCreateLabelID`)
+then creates them. The user wants the analyzer to reuse their existing labels when one fits, only
+inventing a new label when none does.
+
+## Goal
+
+Give the analyzer the list of the user's existing (user-created) labels and instruct it to prefer
+an exact match for the `label` action, inventing a new label only when none fits (marking it as
+new). Dispatch behavior is unchanged (still creates a label if it doesn't exist).
+
+## Decisions (confirmed with user)
+
+- Pass the user's **existing user labels** (not system labels) into the prompt; the LLM prefers
+  them, may still propose a new one when none fits (noting it's new).
+- Dispatch unchanged: `resolveOrCreateLabelID` keeps creating a missing label (the constrained
+  prompt makes invention rare).
+
+## Architecture
+
+### A) Options field — `internal/services/interfaces.go`
+
+`InboxAnalyzerOptions` gains `AvailableLabels []string` (existing user-label names).
+
+### B) Prompt injection — `internal/services/inbox_analyzer_service.go`
+
+New helper, mirroring `prependUserRules`:
+```go
+// prependAvailableLabels prepends an "## Existing labels" block when labels are present, telling
+// the model to prefer an exact existing label for the "label" action. Empty → prompt unchanged.
+func prependAvailableLabels(promptText string, labels []string) string
+```
+Block content (only when `len(labels) > 0`):
+```
+## Existing labels
+These labels already exist in the mailbox: <comma-joined names>
+For the "label" action, PREFER an exact name from this list when one fits. Only invent a NEW label
+when none fits; if you do, keep it short kebab-case and note "(new)" in the category description.
+```
+`Analyze` applies it to the base prompt (after `prependUserRules`, before batching), and
+`BuildPromptPreview` applies it too (so the `v` viewer reflects it). Order: rules block, then
+labels block, then base prompt — both are independent prepends.
+
+### C) TUI population — `internal/tui/action_plan.go`
+
+- A small helper `userLabelNames(labelService) []string`: `ListLabels` → keep only `Type == "user"`
+  → return names. Errors → empty slice (degrade gracefully; analyzer just won't get the list).
+- In `openActionPlanWithText`'s analyze flow, populate `opts.AvailableLabels = a.userLabelNames(...)`
+  alongside the existing options.
+- In `showActionPlanPromptView` (the `v` viewer), populate `AvailableLabels` the same way so the
+  preview matches what Analyze sends.
+
+### D) Dispatch — unchanged
+
+`resolveOrCreateLabelID` keeps its find-or-create behavior. No change.
+
+## Error handling
+
+- `ListLabels` failure → `userLabelNames` returns empty → no labels block → analyzer behaves as
+  before (may invent). Non-fatal.
+- Off the UI thread (analyze runs in a goroutine); the viewer call is synchronous on the UI thread
+  but `ListLabels` is a quick read (label list is small/cached).
+
+## Testing
+
+- `TestPrependAvailableLabels`: with labels → block contains "## Existing labels", the names, and
+  the "PREFER an exact name" instruction; empty → returns the base prompt unchanged.
+- `TestBuildPromptPreview_Labels`: `BuildPromptPreview` with `AvailableLabels` set includes the
+  labels block; without it, no block.
+- `userLabelNames` filtering is covered indirectly (system labels excluded) — if easily unit-testable
+  with a stub LabelService, add `TestUserLabelNames_FiltersSystem`; otherwise rely on the prompt tests.
+
+## Out of scope
+
+- Changing dispatch to not auto-create (user chose to keep creating).
+- A confirmation prompt before creating a new label (deferred; current auto-create stays).
+- Mapping/normalizing near-miss label names (the LLM prefers exact existing names; no fuzzy match).

--- a/docs/superpowers/specs/2026-06-13-analyzer-interests-design.md
+++ b/docs/superpowers/specs/2026-06-13-analyzer-interests-design.md
@@ -1,0 +1,98 @@
+# Analyzer user-interests layer (idea C)
+
+**Date:** 2026-06-13
+**Status:** Approved (design)
+
+## Problem
+
+The user wants the inbox analyzer to factor in their **interests** (e.g. "I'm very interested in
+AI") so emails matching those interests aren't buried in bulk archive/trash and instead get
+surfaced. Today the analyzer only consumes saved free-text rules as behavioral preferences; there
+is no notion of "interest/relevance", and the rules UI ("Analyzer rules" / "New rule:") doesn't
+hint that you can express interests there.
+
+## Goal
+
+Let the user state interests through the existing rules store and have the analyzer treat them as
+relevance signals — surfacing matching emails (priority "high" + a note in the category
+description) rather than burying them. Make this discoverable by relabeling the rules UI. Also fix
+a focus bug where `:plan rules` opens the picker but leaves focus on the message list.
+
+## Decisions (confirmed with user)
+
+- **Reuse the existing rules store** (no new storage/UI for interests) — just reframe the prompt.
+- **Effect:** interest-matching emails get priority "high" and are noted, staying in their action
+  category (no new "of interest" category, no schema change).
+- **Discoverability:** relabel the rules manager / inputs to mention interests.
+- **Bonus fix in scope:** `:plan rules` focus bug (picker opens but focus stays on the list).
+
+## Architecture
+
+### A) Prompt reframe — `internal/services/inbox_analyzer_service.go` (`prependUserRules`)
+
+Change the prepended block heading + add a relevance instruction. From:
+
+```
+## User preferences (respect these rules)
+- <rule>
+```
+
+to:
+
+```
+## User preferences and interests
+Treat the following as BOTH action rules to respect AND interest/relevance signals. When an email
+matches a stated interest, do NOT bury it in a bulk archive/trash group: keep it visible, set that
+category's priority to "high", and note the matched interest in the category description.
+- <rule or interest>
+```
+
+Only emitted when rules exist (unchanged); empty rules → no block, prompt unchanged. Reuses the
+existing `priority` / `description` schema fields (both already rendered:
+`actionVerbLabel · N/M · Name · PRIORITY`). No schema or other code change. The `v` prompt viewer
+(`BuildPromptPreview`) uses `prependUserRules`, so it reflects the new text automatically.
+
+### B) UI relabel — `internal/tui/action_plan_rules.go`
+
+- Rules manager container title: `" 🧠 Analyzer rules "` → `" 🧠 Analyzer rules & interests "`.
+- Add-rule embedded input label: `" New rule: "` → `" Rule or interest: "`.
+- `Ctrl+R` remember-rule panel title: `" 🧠 Remember preference "` →
+  `" 🧠 Remember rule or interest "` (and its footer text stays "Enter save · Esc cancel").
+
+### C) Focus fix — `:plan rules` should take focus
+
+Root cause: `:plan rules` runs `executeActionPlanCommand` → `openAnalyzerRulesManager()`
+synchronously during `executeCommand`, then `hideCommandBar()` → `restoreFocusAfterModal()` runs
+afterward and re-focuses the message list (default branch), clobbering the picker's focus.
+
+Fix (synchronous, mirrors the existing `cmdFocusOverride` precedent used by content search):
+- In `openAnalyzerRulesManager`, after `a.SetFocus(list)` / `a.currentFocus = "analyzer_rules"`,
+  set `a.cmdFocusOverride = "keep"`.
+- In `restoreFocusAfterModal` (`internal/tui/...`), add `case "keep": return` so it leaves the
+  focus the picker already grabbed (and the override is consumed/cleared as usual).
+
+This is synchronous (no `QueueUpdateDraw` defer → no leaked goroutine, no test breakage) because
+`openAnalyzerRulesManager` already runs on the UI thread during command execution.
+
+### D) Docs / `:help` (Definition of Done)
+
+- `:help` command list: note that `:plan rules` manages "rules or interests".
+- `docs/CONFIGURATION.md` (analyzer section): mention you can write action rules **or** interests
+  (e.g. "I'm interested in AI") in `:plan rules` / `Ctrl+R`, and that the analyzer raises the
+  priority of emails matching your interests.
+
+## Testing
+
+- `TestPrependUserRules_Interests`: with rules → output contains "User preferences and interests",
+  the relevance instruction substring, and the rule text; with empty rules → no block (unchanged).
+- `TestAnalyzerRulesPickerSetsFocusOverride`: `openAnalyzerRulesManager()` sets
+  `currentFocus == "analyzer_rules"` AND `cmdFocusOverride == "keep"` (synchronous — extends the
+  existing `TestAnalyzerRulesPickerSwap` setup).
+- `TestRestoreFocusAfterModal_Keep`: with `cmdFocusOverride == "keep"`, `restoreFocusAfterModal()`
+  does NOT change `currentFocus` to "list" and clears the override.
+
+## Out of scope
+
+- Separate interests storage/UI (reuse rules — decided).
+- A dedicated "of interest" category or per-email priority (schema is category-level — decided).
+- Sorting categories by priority (possible later; not needed — priority is already displayed).

--- a/docs/superpowers/specs/2026-06-13-analyzer-summarize-action-design.md
+++ b/docs/superpowers/specs/2026-06-13-analyzer-summarize-action-design.md
@@ -69,10 +69,11 @@ func (a *App) dispatchActionPlanSummarize(state *actionPlanState)
   - Build the digest input with a pure helper `buildSummarizeInput(ids, bodies, metaByID, limit)`
     → a numbered "Subject / From / body(≤limit)" blob (reusing `truncateForAnalyzer`-style trim;
     `limit` = `a.Config.InboxAnalyzer.BodyCharLimit`).
-  - Call `aiService.GenerateSummaryStream(ctx, blob, options, onToken)` where `onToken` appends
-    **directly** to the TextView (NEVER `QueueUpdateDraw` — streaming-callback rule), guarded by
-    `ctx.Err()`/state-still-active checks.
-  - On completion, render the final text through `renderPromptResult` (Markdown) and set it.
+  - Call `aiService.GenerateSummary(ctx, blob, options)` (non-streaming — one shot). On return,
+    render the result through `renderPromptResult` (Markdown) and set it via a single
+    `a.QueueUpdateDraw(...)` (the standard safe worker→UI update; avoids the per-token
+    streaming-callback deadlock class entirely). The "⏳ Summarizing N emails…" placeholder covers
+    the wait. Guard the final update on `a.actionPlanState == state` / `ctx.Err() == nil`.
 - Esc restores the tree (`renderActionPlanPanel(state)`), `currentFocus = "action_plan"`.
 
 The AI digest framing (a short "what's new across these emails" instruction) is passed via the
@@ -87,8 +88,8 @@ Add `"action_plan_summary"` to the global pass-through sentinel line (next to
 
 - Body fetch + AI call run on a worker goroutine (off the UI thread). `GetMessagePlainTexts` and
   the final `ShowError`/`ShowWarning` are safe there.
-- Streaming tokens update the TextView via **direct `SetText`/append**, never `QueueUpdateDraw`
-  (matches the AI-summary streaming pattern and avoids the ESC-deadlock class).
+- Non-streaming: a single `QueueUpdateDraw` renders the final digest from the worker goroutine —
+  the standard safe pattern; no per-token callback, so no streaming/ESC-deadlock class to worry about.
 - Esc restore is synchronous (no `QueueUpdateDraw`).
 - No checked emails → warning, no panel.
 
@@ -102,7 +103,7 @@ Add `"action_plan_summary"` to the global pass-through sentinel line (next to
 - `TestActionPlanSummarizeSwap` (mirror `TestActionPlanMoveInlineSwap`): `dispatchActionPlanSummarize`
   with a stub AIService body-swaps the tree for a TextView and sets `currentFocus ==
   "action_plan_summary"`; Esc restores the tree (`currentFocus == "action_plan"`). (Use a stub
-  AIService whose `GenerateSummaryStream` returns immediately so the test is deterministic.)
+  AIService whose `GenerateSummary` returns a fixed result so the test is deterministic.)
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-06-13-analyzer-summarize-action-design.md
+++ b/docs/superpowers/specs/2026-06-13-analyzer-summarize-action-design.md
@@ -1,0 +1,112 @@
+# Analyzer "summarize" action — combined AI digest (idea B)
+
+**Date:** 2026-06-13
+**Status:** Approved (design)
+
+## Problem
+
+The Action Plan only offers archive / trash / mark-read / label / none. The user wants a category
+for emails they'd like a **quick AI digest** of (not read fully, not discarded) — e.g. newsletters
+or threads worth skimming.
+
+## Goal
+
+Add a `summarize` action the analyzer can assign to a category; dispatching it generates a single
+combined AI digest of that category's emails, shown in an in-place panel inside the Action Plan
+(Markdown-rendered, streaming), with Esc returning to the tree.
+
+## Decisions (confirmed with user)
+
+- **Output:** one **combined digest** (single AI call over all the category's emails), not per-email.
+- **View:** an **in-place body-swap panel** in the Action Plan (like the `v` prompt viewer / move
+  chooser), Markdown-rendered, Esc returns.
+- Reuse existing infra: body-swap pattern, `GetMessagePlainTexts` (bodies), `renderPromptResult`
+  (Markdown), `AIService.GenerateSummaryStream` (streaming).
+
+## Architecture
+
+### A) Prompt — `internal/services/inbox_analyzer_prompt.txt`
+
+Add to the "exact set" of actions:
+```
+  "summarize" — worth a quick AI digest; not full reading, not discarding
+```
+(The JSON schema's `action` field already accepts any string; the analyzer service's
+`normalizePriority`/merge are action-agnostic, so no parser change is needed.)
+
+### B) Action metadata — `internal/tui/action_plan.go`
+
+- `actionVerbLabel("summarize")` → `"summarize"`.
+- `actionRuleVerbShort("summarize")` → `"digest"` (footer short form).
+- `actionKeyHint("summarize")` → `a.Keys.Summarize` (the `y` key) so the footer shows
+  `y to digest (N)` for a summarize category.
+
+### C) Dispatch trigger — `internal/tui/action_plan.go` (`actionPlanInputCapture`)
+
+In the action-key `switch key { ... }`, add:
+```go
+	case a.Keys.Summarize:
+		a.dispatchActionPlanSummarize(state)
+		return nil
+```
+This summarizes the currently-focused category's checked emails (works on any category; it's the
+action the analyzer suggests for ones worth skimming). Gated behind the existing
+`if state.analyzing.Load() { return nil }` like the other quick actions.
+
+### D) `dispatchActionPlanSummarize` — new `internal/tui/action_plan_summarize.go`
+
+```go
+func (a *App) dispatchActionPlanSummarize(state *actionPlanState)
+```
+- Resolve the focused category (`currentActionPlanCategory`); `checkedIDs` for its messages. If
+  none checked → `go ...ShowWarning("nothing to summarize")` and return.
+- Body-swap the tree for a read-only, scrollable `*tview.TextView` showing "⏳ Summarizing N
+  emails…"; `a.currentFocus = "action_plan_summary"`; Esc input-capture → restore (mirrors
+  `showActionPlanMoveChooser`'s restore).
+- In a goroutine:
+  - Fetch bodies via `emailService.GetMessagePlainTexts(ctx, ids, 0)` (degrade to snippet from
+    `state.metaByID` when a body is missing).
+  - Build the digest input with a pure helper `buildSummarizeInput(ids, bodies, metaByID, limit)`
+    → a numbered "Subject / From / body(≤limit)" blob (reusing `truncateForAnalyzer`-style trim;
+    `limit` = `a.Config.InboxAnalyzer.BodyCharLimit`).
+  - Call `aiService.GenerateSummaryStream(ctx, blob, options, onToken)` where `onToken` appends
+    **directly** to the TextView (NEVER `QueueUpdateDraw` — streaming-callback rule), guarded by
+    `ctx.Err()`/state-still-active checks.
+  - On completion, render the final text through `renderPromptResult` (Markdown) and set it.
+- Esc restores the tree (`renderActionPlanPanel(state)`), `currentFocus = "action_plan"`.
+
+The AI digest framing (a short "what's new across these emails" instruction) is passed via the
+summary content/options; reuse `SummaryOptions` defaults. Errors → `go ...ShowError` + restore.
+
+### E) keys.go
+
+Add `"action_plan_summary"` to the global pass-through sentinel line (next to
+`action_plan_prompt` etc.) so the TextView owns its keys.
+
+## Error handling / threading
+
+- Body fetch + AI call run on a worker goroutine (off the UI thread). `GetMessagePlainTexts` and
+  the final `ShowError`/`ShowWarning` are safe there.
+- Streaming tokens update the TextView via **direct `SetText`/append**, never `QueueUpdateDraw`
+  (matches the AI-summary streaming pattern and avoids the ESC-deadlock class).
+- Esc restore is synchronous (no `QueueUpdateDraw`).
+- No checked emails → warning, no panel.
+
+## Testing
+
+- `TestActionVerb_Summarize`: `actionVerbLabel("summarize")=="summarize"`,
+  `actionRuleVerbShort("summarize")=="digest"`, and `actionKeyHint("summarize")` returns the
+  configured Summarize key.
+- `TestBuildSummarizeInput`: builds a numbered blob from IDs + bodies (+ snippet fallback when a
+  body is absent), truncated to the limit.
+- `TestActionPlanSummarizeSwap` (mirror `TestActionPlanMoveInlineSwap`): `dispatchActionPlanSummarize`
+  with a stub AIService body-swaps the tree for a TextView and sets `currentFocus ==
+  "action_plan_summary"`; Esc restores the tree (`currentFocus == "action_plan"`). (Use a stub
+  AIService whose `GenerateSummaryStream` returns immediately so the test is deterministic.)
+
+## Out of scope
+
+- Per-email summaries (combined digest only — decided).
+- Persisting/caching the digest (one-shot view).
+- A bulk Gmail action on summarize categories (summarize only produces a digest; the user can then
+  archive/etc. via the normal keys).

--- a/internal/services/inbox_analyzer_prompt.txt
+++ b/internal/services/inbox_analyzer_prompt.txt
@@ -13,6 +13,7 @@ Rules:
   "trash"     — clearly unwanted
   "label"     — needs follow-up; provide a short kebab-case "label" value
   "none"      — no safe bulk action; user should decide
+  "summarize" — worth a quick AI digest; not full reading, not discarding
 - priority is one of "high", "medium", "low".
 
 Return ONLY a JSON object, no prose, no markdown fences, in exactly this shape:

--- a/internal/services/inbox_analyzer_service.go
+++ b/internal/services/inbox_analyzer_service.go
@@ -273,7 +273,12 @@ func prependUserRules(promptText string, rules []string) string {
 	if len(clean) == 0 {
 		return promptText
 	}
-	return "## User preferences (respect these rules)\n" + strings.Join(clean, "\n") + "\n\n" + promptText
+	header := "## User preferences and interests\n" +
+		"Treat the following as BOTH action rules to respect AND interest/relevance signals. " +
+		"When an email matches a stated interest, do NOT bury it in a bulk archive/trash group: " +
+		"keep it visible, set that category's priority to \"high\", and note the matched interest " +
+		"in the category description.\n"
+	return header + strings.Join(clean, "\n") + "\n\n" + promptText
 }
 
 func (s *InboxAnalyzerServiceImpl) Analyze(ctx context.Context, messages []AnalyzerMessage, opts InboxAnalyzerOptions, onProgress func(*ActionPlan)) (*ActionPlan, error) {

--- a/internal/services/inbox_analyzer_service.go
+++ b/internal/services/inbox_analyzer_service.go
@@ -258,7 +258,28 @@ func (s *InboxAnalyzerServiceImpl) BuildPromptPreview(opts InboxAnalyzerOptions)
 	if strings.TrimSpace(base) == "" {
 		base = defaultAnalyzerPrompt
 	}
-	return prependUserRules(base, opts.UserRules)
+	withRules := prependUserRules(base, opts.UserRules)
+	return prependAvailableLabels(withRules, opts.AvailableLabels)
+}
+
+// prependAvailableLabels prepends an "## Existing labels" block when labels are present, telling
+// the model to prefer an exact existing label for the "label" action. Empty → prompt unchanged.
+func prependAvailableLabels(promptText string, labels []string) string {
+	clean := make([]string, 0, len(labels))
+	for _, l := range labels {
+		if strings.TrimSpace(l) != "" {
+			clean = append(clean, strings.TrimSpace(l))
+		}
+	}
+	if len(clean) == 0 {
+		return promptText
+	}
+	header := "## Existing labels\n" +
+		"These labels already exist in the mailbox: " + strings.Join(clean, ", ") + "\n" +
+		"For the \"label\" action, PREFER an exact name from this list when one fits. Only invent a " +
+		"NEW label when none fits; if you do, keep it short kebab-case and note \"(new)\" in the " +
+		"category description.\n\n"
+	return header + promptText
 }
 
 // prependUserRules adds a "## User preferences" block before the analyzer prompt
@@ -295,6 +316,7 @@ func (s *InboxAnalyzerServiceImpl) Analyze(ctx context.Context, messages []Analy
 	}
 
 	promptText = prependUserRules(promptText, opts.UserRules)
+	promptText = prependAvailableLabels(promptText, opts.AvailableLabels)
 
 	batches := splitBatches(messages, opts.BatchSize, opts.MaxBatches)
 	plan := &ActionPlan{BatchesTotal: len(batches)}

--- a/internal/services/inbox_analyzer_service_test.go
+++ b/internal/services/inbox_analyzer_service_test.go
@@ -344,3 +344,19 @@ func TestBuildPromptPreview(t *testing.T) {
 		t.Fatalf("no rules → no preferences block: %q", out)
 	}
 }
+
+func TestPrependUserRules_Interests(t *testing.T) {
+	got := prependUserRules("BASEPROMPT", []string{"interested in AI"})
+	if !strings.Contains(got, "## User preferences and interests") {
+		t.Fatalf("expected reframed heading, got:\n%s", got)
+	}
+	if !strings.Contains(got, "interest/relevance") {
+		t.Fatalf("expected the relevance instruction, got:\n%s", got)
+	}
+	if !strings.Contains(got, "interested in AI") || !strings.Contains(got, "BASEPROMPT") {
+		t.Fatalf("expected rule text + base prompt, got:\n%s", got)
+	}
+	if prependUserRules("BASEPROMPT", nil) != "BASEPROMPT" {
+		t.Fatal("empty rules must return the base prompt unchanged")
+	}
+}

--- a/internal/services/inbox_analyzer_service_test.go
+++ b/internal/services/inbox_analyzer_service_test.go
@@ -360,3 +360,34 @@ func TestPrependUserRules_Interests(t *testing.T) {
 		t.Fatal("empty rules must return the base prompt unchanged")
 	}
 }
+
+func TestPrependAvailableLabels(t *testing.T) {
+	got := prependAvailableLabels("BASEPROMPT", []string{"work", "receipts"})
+	if !strings.Contains(got, "## Existing labels") {
+		t.Fatalf("expected labels heading, got:\n%s", got)
+	}
+	if !strings.Contains(got, "work") || !strings.Contains(got, "receipts") {
+		t.Fatalf("expected label names, got:\n%s", got)
+	}
+	if !strings.Contains(got, "PREFER an exact name") {
+		t.Fatalf("expected the prefer-existing instruction, got:\n%s", got)
+	}
+	if !strings.Contains(got, "BASEPROMPT") {
+		t.Fatalf("expected base prompt retained, got:\n%s", got)
+	}
+	if prependAvailableLabels("BASEPROMPT", nil) != "BASEPROMPT" {
+		t.Fatal("empty labels must return the base prompt unchanged")
+	}
+}
+
+func TestBuildPromptPreview_Labels(t *testing.T) {
+	s := NewInboxAnalyzerService(nil)
+	out := s.BuildPromptPreview(InboxAnalyzerOptions{AvailableLabels: []string{"work"}})
+	if !strings.Contains(out, "## Existing labels") || !strings.Contains(out, "work") {
+		t.Fatalf("preview should include the labels block, got:\n%s", out)
+	}
+	out = s.BuildPromptPreview(InboxAnalyzerOptions{})
+	if strings.Contains(out, "## Existing labels") {
+		t.Fatalf("no labels → no labels block, got:\n%s", out)
+	}
+}

--- a/internal/services/interfaces.go
+++ b/internal/services/interfaces.go
@@ -1010,6 +1010,7 @@ type InboxAnalyzerOptions struct {
 	CustomPromptText string   // empty → use the built-in default analyzer prompt
 	UserRules        []string // free-text preference rules prepended to the prompt; empty → none
 	BodyCharLimit    int      // max body chars rendered per email; <= 0 → no extra trim
+	AvailableLabels  []string // existing user-label names; analyzer prefers these for the "label" action
 }
 
 // InboxAnalyzerService groups unread messages into an actionable plan via the LLM.

--- a/internal/tui/action_plan.go
+++ b/internal/tui/action_plan.go
@@ -113,6 +113,8 @@ func actionVerbLabel(action string) string {
 		return "Trash"
 	case "label":
 		return "Label"
+	case "summarize":
+		return "summarize"
 	default:
 		return "Review"
 	}
@@ -129,6 +131,8 @@ func (a *App) actionKeyHint(action string) string {
 		return a.Keys.Trash
 	case "label":
 		return a.Keys.ManageLabels
+	case "summarize":
+		return a.Keys.Summarize
 	default:
 		return ""
 	}
@@ -567,6 +571,8 @@ func actionRuleVerbShort(action string) string {
 		return "trash"
 	case "label":
 		return "label"
+	case "summarize":
+		return "digest"
 	default:
 		return "act"
 	}

--- a/internal/tui/action_plan.go
+++ b/internal/tui/action_plan.go
@@ -755,6 +755,9 @@ func (a *App) actionPlanInputCapture(state *actionPlanState) func(*tcell.EventKe
 		case a.Keys.ManageLabels:
 			a.executeActionPlanAction(state, "label")
 			return nil
+		case a.Keys.Summarize:
+			a.dispatchActionPlanSummarize(state)
+			return nil
 		}
 		return ev
 	}

--- a/internal/tui/action_plan.go
+++ b/internal/tui/action_plan.go
@@ -284,6 +284,10 @@ func (a *App) openActionPlanWithText(customPromptText string) {
 		}
 	}
 
+	// Existing user labels so the analyzer prefers them for the "label" action (read outside the
+	// analysis goroutine to avoid racing it).
+	availableLabels := a.userLabelNames()
+
 	// Enrich the analyzer context with each email's plain-text body (opt-in). Cap to what is
 	// actually analyzed (BatchSize x MaxBatches) so we never fetch bodies for messages the
 	// analyzer would drop. Failures degrade gracefully to the snippet (Body left empty).
@@ -333,7 +337,7 @@ func (a *App) openActionPlanWithText(customPromptText string) {
 		}()
 
 		_, err := a.GetInboxAnalyzerService().Analyze(ctx, messages,
-			services.InboxAnalyzerOptions{BatchSize: batchSize, MaxBatches: maxBatches, CustomPromptText: customPromptText, UserRules: userRules, BodyCharLimit: bodyCharLimit},
+			services.InboxAnalyzerOptions{BatchSize: batchSize, MaxBatches: maxBatches, CustomPromptText: customPromptText, UserRules: userRules, BodyCharLimit: bodyCharLimit, AvailableLabels: availableLabels},
 			func(p *services.ActionPlan) {
 				// Per-batch progress callback (low frequency, NOT per-token). Marshal the
 				// render onto the UI thread via QueueUpdateDraw: a bare SetText from a
@@ -748,6 +752,26 @@ func (a *App) actionPlanInputCapture(state *actionPlanState) func(*tcell.EventKe
 		}
 		return ev
 	}
+}
+
+// userLabelNames returns the names of the user's own labels (excluding Gmail system labels),
+// for feeding the analyzer so it prefers existing labels. Errors degrade to an empty slice.
+func (a *App) userLabelNames() []string {
+	_, _, labelService, _, _, _, _, _, _, _, _, _ := a.GetServices()
+	if labelService == nil {
+		return nil
+	}
+	labels, err := labelService.ListLabels(a.ctx)
+	if err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(labels))
+	for _, l := range labels {
+		if l != nil && l.Type == "user" {
+			out = append(out, l.Name)
+		}
+	}
+	return out
 }
 
 // currentActionPlanCategory returns the selected category or nil.

--- a/internal/tui/action_plan_prompt.go
+++ b/internal/tui/action_plan_prompt.go
@@ -29,6 +29,7 @@ func (a *App) showActionPlanPromptView(state *actionPlanState) {
 		CustomPromptText: state.customPromptText,
 		UserRules:        userRules,
 		BodyCharLimit:    a.Config.InboxAnalyzer.BodyCharLimit,
+		AvailableLabels:  a.userLabelNames(),
 	}
 	prompt := svc.BuildPromptPreview(opts)
 

--- a/internal/tui/action_plan_rules.go
+++ b/internal/tui/action_plan_rules.go
@@ -64,7 +64,7 @@ func (a *App) showRememberRuleModal(suggestion string) {
 	state.container.RemoveItem(state.footer)
 	state.container.AddItem(input, 1, 0, true)
 	state.container.AddItem(state.footer, 1, 0, false)
-	state.container.SetTitle(" 🧠 Remember preference ")
+	state.container.SetTitle(" 🧠 Remember rule or interest ")
 	state.footer.SetText(" Enter save · Esc cancel ")
 	a.currentFocus = "action_plan_rule"
 	a.SetFocus(input)
@@ -92,7 +92,7 @@ func (a *App) openAnalyzerRulesManager() {
 	container := tview.NewFlex().SetDirection(tview.FlexRow)
 	container.SetBackgroundColor(colors.Background.Color())
 	container.SetBorder(true)
-	container.SetTitle(" 🧠 Analyzer rules ")
+	container.SetTitle(" 🧠 Analyzer rules & interests ")
 	container.SetTitleColor(colors.Title.Color())
 	container.SetBorderColor(colors.Border.Color())
 
@@ -139,7 +139,7 @@ func (a *App) openAnalyzerRulesManager() {
 
 	// showAddInput body-swaps the list for an input field inside the same container.
 	showAddInput := func() {
-		input := tview.NewInputField().SetLabel(" New rule: ").SetFieldWidth(0)
+		input := tview.NewInputField().SetLabel(" Rule or interest: ").SetFieldWidth(0)
 		input.SetBackgroundColor(colors.Background.Color())
 		input.SetFieldBackgroundColor(colors.Background.Color())
 		input.SetFieldTextColor(colors.Text.Color())

--- a/internal/tui/action_plan_rules.go
+++ b/internal/tui/action_plan_rules.go
@@ -216,4 +216,7 @@ func (a *App) openAnalyzerRulesManager() {
 	a.setActivePicker(PickerAnalyzerRules)
 	a.currentFocus = "analyzer_rules"
 	a.SetFocus(list)
+	// :plan rules runs during command execution; hideCommandBar()'s restoreFocusAfterModal()
+	// would otherwise re-focus the message list afterward. "keep" tells it to leave our focus.
+	a.cmdFocusOverride = "keep"
 }

--- a/internal/tui/action_plan_rules_test.go
+++ b/internal/tui/action_plan_rules_test.go
@@ -108,3 +108,24 @@ func TestRememberRuleInlineSwap(t *testing.T) {
 		t.Fatal("after Esc, the tree should be restored as the container body")
 	}
 }
+
+func TestAnalyzerRulesPickerSetsFocusKeepOverride(t *testing.T) {
+	a := newRulesTestApp()
+	a.openAnalyzerRulesManager()
+	if a.cmdFocusOverride != "keep" {
+		t.Fatalf("expected cmdFocusOverride=keep so the command bar teardown won't steal focus, got %q", a.cmdFocusOverride)
+	}
+}
+
+func TestRestoreFocusAfterModal_Keep(t *testing.T) {
+	a := newRulesTestApp()
+	a.currentFocus = "analyzer_rules"
+	a.cmdFocusOverride = "keep"
+	a.restoreFocusAfterModal()
+	if a.currentFocus != "analyzer_rules" {
+		t.Fatalf("keep override must not re-focus the list, got %q", a.currentFocus)
+	}
+	if a.cmdFocusOverride != "" {
+		t.Fatalf("override should be consumed, got %q", a.cmdFocusOverride)
+	}
+}

--- a/internal/tui/action_plan_summarize.go
+++ b/internal/tui/action_plan_summarize.go
@@ -1,0 +1,119 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ajramos/giztui/internal/services"
+	tcell "github.com/derailed/tcell/v2"
+	"github.com/derailed/tview"
+	gmailapi "google.golang.org/api/gmail/v1"
+)
+
+// buildSummarizeInput renders the category's emails into a numbered blob for the AI digest:
+// "N. Subject: … | From: …\n   <body up to limit, or snippet if no body>". metaByID supplies
+// subject/from/snippet; bodies (id->plain text) supplies the body when available.
+func buildSummarizeInput(ids []string, bodies map[string]string, metaByID map[string]*gmailapi.Message, limit int) string {
+	var b strings.Builder
+	for i, id := range ids {
+		subject, from, snippet := "(unknown)", "", ""
+		if m := metaByID[id]; m != nil {
+			subject = extractHeaderValue(m, "Subject")
+			from = extractHeaderValue(m, "From")
+			snippet = m.Snippet
+		}
+		body := bodies[id]
+		if strings.TrimSpace(body) == "" {
+			body = snippet
+		}
+		fmt.Fprintf(&b, "%d. Subject: %s | From: %s\n   %s\n", i+1, subject, from, truncateForSummary(body, limit))
+	}
+	return b.String()
+}
+
+// truncateForSummary collapses whitespace and cuts to limit runes (limit <= 0 → no cut).
+func truncateForSummary(text string, limit int) string {
+	collapsed := strings.TrimSpace(strings.Join(strings.Fields(text), " "))
+	if limit <= 0 || len([]rune(collapsed)) <= limit {
+		return collapsed
+	}
+	return string([]rune(collapsed)[:limit])
+}
+
+// dispatchActionPlanSummarize body-swaps the tree for an in-place panel showing a combined AI
+// digest of the focused category's checked emails. Esc returns to the tree.
+func (a *App) dispatchActionPlanSummarize(state *actionPlanState) {
+	cat := a.currentActionPlanCategory(state)
+	if cat == nil {
+		return
+	}
+	ids := checkedIDs(cat.MessageIDs, state.excluded)
+	if len(ids) == 0 {
+		go a.GetErrorHandler().ShowWarning(a.ctx, "All emails in this category are excluded — nothing to summarize")
+		return
+	}
+
+	colors := a.GetComponentColors("ai")
+	view := tview.NewTextView().SetWrap(true).SetWordWrap(true)
+	view.SetBackgroundColor(colors.Background.Color())
+	view.SetTextColor(colors.Text.Color())
+	view.SetText(fmt.Sprintf("⏳ Summarizing %d email(s)…", len(ids)))
+
+	restore := func() {
+		state.container.RemoveItem(view)
+		state.container.RemoveItem(state.footer)
+		state.container.AddItem(state.tree, 0, 1, true)
+		state.container.AddItem(state.footer, 1, 0, false)
+		a.currentFocus = "action_plan"
+		a.SetFocus(state.tree)
+		a.renderActionPlanPanel(state)
+	}
+	view.SetInputCapture(func(ev *tcell.EventKey) *tcell.EventKey {
+		if ev.Key() == tcell.KeyEscape {
+			restore()
+			return nil
+		}
+		return ev
+	})
+
+	state.container.RemoveItem(state.tree)
+	state.container.RemoveItem(state.footer)
+	state.container.AddItem(view, 0, 1, true)
+	state.container.AddItem(state.footer, 1, 0, false)
+	state.container.SetTitle(fmt.Sprintf(" 📝 Digest of %q ", cat.Name))
+	state.footer.SetText(" ↑/↓ scroll  |  Esc to go back ")
+	a.currentFocus = "action_plan_summary"
+	a.SetFocus(view)
+
+	limit := 1000
+	if a.Config != nil {
+		limit = a.Config.InboxAnalyzer.BodyCharLimit
+	}
+	emailService, aiService, _, _, _, _, _, _, _, _, _, _ := a.GetServices()
+	go func() {
+		var bodies map[string]string
+		if emailService != nil {
+			bodies, _ = emailService.GetMessagePlainTexts(a.ctx, ids, 0)
+		}
+		blob := buildSummarizeInput(ids, bodies, state.metaByID, limit)
+		if aiService == nil {
+			a.QueueUpdateDraw(func() {
+				if a.actionPlanState == state {
+					view.SetText("⚠️ AI service not available")
+				}
+			})
+			return
+		}
+		res, err := aiService.GenerateSummary(a.ctx, blob, services.SummaryOptions{})
+		a.QueueUpdateDraw(func() {
+			if a.actionPlanState != state || a.ctx.Err() != nil {
+				return
+			}
+			if err != nil {
+				view.SetText(fmt.Sprintf("⚠️ Could not summarize: %v", err))
+				return
+			}
+			view.SetText(a.renderPromptResult(res.Summary))
+		})
+	}()
+}

--- a/internal/tui/action_plan_summarize_test.go
+++ b/internal/tui/action_plan_summarize_test.go
@@ -1,0 +1,103 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/ajramos/giztui/internal/services"
+	tcell "github.com/derailed/tcell/v2"
+	"github.com/derailed/tview"
+	gmailapi "google.golang.org/api/gmail/v1"
+)
+
+type stubAISummary struct{}
+
+func (stubAISummary) GenerateSummary(ctx context.Context, content string, o services.SummaryOptions) (*services.SummaryResult, error) {
+	return &services.SummaryResult{Summary: "DIGEST RESULT"}, nil
+}
+func (stubAISummary) GenerateSummaryStream(ctx context.Context, content string, o services.SummaryOptions, onToken func(string)) (*services.SummaryResult, error) {
+	return &services.SummaryResult{Summary: "DIGEST RESULT"}, nil
+}
+func (stubAISummary) GenerateReply(ctx context.Context, content string, o services.ReplyOptions) (string, error) {
+	return "", nil
+}
+func (stubAISummary) SuggestLabels(ctx context.Context, content string, l []string) ([]string, error) {
+	return nil, nil
+}
+func (stubAISummary) FormatContent(ctx context.Context, content string, o services.FormatOptions) (string, error) {
+	return content, nil
+}
+func (stubAISummary) ApplyCustomPrompt(ctx context.Context, p string, v map[string]string) (string, error) {
+	return "", nil
+}
+func (stubAISummary) ApplyCustomPromptStream(ctx context.Context, p string, v map[string]string, onToken func(string)) (string, error) {
+	return "", nil
+}
+
+func TestActionPlanSummarizeSwap(t *testing.T) {
+	a := &App{Application: tview.NewApplication()}
+	a.ctx = context.Background()
+	a.aiService = stubAISummary{}
+	state := &actionPlanState{
+		plan: &services.ActionPlan{Categories: []services.ActionPlanCategory{
+			{Name: "News", Action: "summarize", MessageIDs: []string{"m1"}},
+		}},
+		selectedCategory: 0,
+		excluded:         map[string]bool{},
+		expanded:         map[int]bool{},
+		metaByID:         map[string]*gmailapi.Message{"m1": {Id: "m1", Snippet: "s"}},
+		footer:           tview.NewTextView(),
+	}
+	state.root = tview.NewTreeNode("")
+	state.tree = tview.NewTreeView().SetRoot(state.root)
+	state.container = tview.NewFlex().SetDirection(tview.FlexRow)
+	state.container.AddItem(state.tree, 0, 1, true)
+	state.container.AddItem(state.footer, 1, 0, false)
+	a.actionPlanState = state
+
+	a.dispatchActionPlanSummarize(state)
+	if a.currentFocus != "action_plan_summary" {
+		t.Fatalf("expected currentFocus=action_plan_summary, got %q", a.currentFocus)
+	}
+	if state.container.ItemAt(0) == state.tree {
+		t.Fatal("tree should be swapped out for the summary view")
+	}
+	view, ok := a.GetFocus().(*tview.TextView)
+	if !ok {
+		t.Fatalf("expected the summary TextView focused, got %T", a.GetFocus())
+	}
+	if cap := view.GetInputCapture(); cap != nil {
+		cap(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone))
+	}
+	if a.currentFocus != "action_plan" {
+		t.Fatalf("after Esc, currentFocus should be action_plan, got %q", a.currentFocus)
+	}
+	if a.actionPlanState.container.ItemAt(0) != state.tree {
+		t.Fatal("after Esc the tree should be restored")
+	}
+}
+
+func TestBuildSummarizeInput(t *testing.T) {
+	meta := map[string]*gmailapi.Message{
+		"m1": {Id: "m1", Snippet: "snip1", Payload: &gmailapi.MessagePart{Headers: []*gmailapi.MessagePartHeader{
+			{Name: "Subject", Value: "Hello"}, {Name: "From", Value: "a@x.com"},
+		}}},
+		"m2": {Id: "m2", Snippet: "snip2", Payload: &gmailapi.MessagePart{Headers: []*gmailapi.MessagePartHeader{
+			{Name: "Subject", Value: "World"}, {Name: "From", Value: "b@x.com"},
+		}}},
+	}
+	bodies := map[string]string{"m1": "full body one"}
+
+	out := buildSummarizeInput([]string{"m1", "m2"}, bodies, meta, 1000)
+
+	if !strings.Contains(out, "Hello") || !strings.Contains(out, "a@x.com") {
+		t.Fatalf("missing m1 subject/from:\n%s", out)
+	}
+	if !strings.Contains(out, "full body one") {
+		t.Fatalf("m1 should use its body:\n%s", out)
+	}
+	if !strings.Contains(out, "snip2") {
+		t.Fatalf("m2 has no body → should fall back to snippet:\n%s", out)
+	}
+}

--- a/internal/tui/action_plan_test.go
+++ b/internal/tui/action_plan_test.go
@@ -410,3 +410,17 @@ func TestActionPlanPromptViewSwap(t *testing.T) {
 		t.Fatal("after Esc, the tree should be restored as the container body")
 	}
 }
+
+func TestActionVerb_Summarize(t *testing.T) {
+	if got := actionVerbLabel("summarize"); got != "summarize" {
+		t.Fatalf("actionVerbLabel(summarize)=%q", got)
+	}
+	if got := actionRuleVerbShort("summarize"); got != "digest" {
+		t.Fatalf("actionRuleVerbShort(summarize)=%q", got)
+	}
+	a := &App{}
+	a.Keys.Summarize = "y"
+	if got := a.actionKeyHint("summarize"); got != "y" {
+		t.Fatalf("actionKeyHint(summarize)=%q, want y", got)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2388,6 +2388,7 @@ func (a *App) generateHelpText() string {
 	fmt.Fprintf(&help, "    %-18s 🧾  Toggle AI touch-up of rendered text\n", ":touch-up")
 	fmt.Fprintf(&help, "    %-18s 👤  Open account picker (alias :acc)\n", ":accounts")
 	fmt.Fprintf(&help, "    %-18s 🧠  Open inbox Action Plan (alias :plan, :ap)\n", ":action-plan")
+	fmt.Fprintf(&help, "    %-18s 🧠  Manage analyzer rules/interests (e.g. 'interested in AI')\n", ":plan rules")
 	fmt.Fprintf(&help, "    %-18s ⟳   Toggle background inbox auto-refresh (alias :arr; :arr 2m sets interval)\n", ":autorefresh")
 	fmt.Fprintf(&help, "    %-18s ⚙️   Add new config options to your config.json (backup written)\n", ":config migrate")
 

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -578,7 +578,8 @@ func (a *App) bindKeys() {
 		// this pass-through it would swallow their Esc/Ctrl+P/Enter (see prompt-preview bug).
 		if a.currentFocus == "prompt_preview" || a.currentFocus == "action_plan_move" ||
 			a.currentFocus == "analyzer_rules" || a.currentFocus == "analyzer_rules_add" ||
-			a.currentFocus == "action_plan_rule" || a.currentFocus == "action_plan_prompt" {
+			a.currentFocus == "action_plan_rule" || a.currentFocus == "action_plan_prompt" ||
+			a.currentFocus == "action_plan_summary" {
 			return event
 		}
 

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -1642,6 +1642,9 @@ func (a *App) restoreFocusAfterModal() {
 				a.updateFocusIndicators("text")
 				return
 			}
+		case "keep":
+			// A picker/command already set focus (e.g. :plan rules); leave it as-is.
+			return
 		}
 	}
 


### PR DESCRIPTION
Cablea la integración de [graphify](https://github.com/sponsors/safishamsi) (grafo de conocimiento del codebase) en el flujo de Claude Code.

## Cambios (3 ficheros)
- **CLAUDE.md** — nueva sección `## graphify`: para preguntas sobre el código usar `graphify query/path/explain` primero; tras modificar código, `graphify update .` (solo AST, sin coste de API).
- **.claude/settings.json** — dos hooks `PreToolUse` (matchers `Bash` y `Read|Glob`) que, **solo si existe `graphify-out/graph.json`**, recuerdan usar graphify antes de grep/find o de leer ficheros fuente en crudo.
- **.gitignore** — ignora `graphify-out/` (se regenera con `/graphify` o `graphify update`).

## Notas
- Cambios solo de configuración/herramienta; no toca código de la app.
- El grafo en sí (`graphify-out/`) no se commitea; se regenera localmente.

> ⚠️ Hasta que se haga `push` de `main`, este PR mostrará también los commits del *analyzer* que aún no están en `origin/main`. En cuanto `main` esté pusheado, el diff queda reducido a este único commit de graphify.