### PR TITLE
Desktop packaging: CI build matrix + local DMG + Homebrew cask

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,0 +1,191 @@
+name: Release Desktop
+
+# Builds the Wails desktop client per-OS (no cross-compile) and attaches the
+# installers to the GitHub Release for the tag. Kept separate from release.yml
+# (the TUI CLI) so a desktop-packaging failure never blocks the CLI release.
+#
+# Phase 1 ships UNSIGNED artifacts (Gatekeeper/SmartScreen will warn). See
+# docs/DESKTOP_DISTRIBUTION.md for the design and the signing/notarization plan.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build (e.g. v1.21.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  WAILS_VERSION: v2.10.2
+  GO_VERSION: '1.25.12'
+  NODE_VERSION: '20'
+
+jobs:
+  # ---------------------------------------------------------------- macOS .dmg
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - id: ver
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then TAG="${{ github.event.inputs.version }}"; else TAG="${GITHUB_REF#refs/tags/}"; fi
+          echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
+          echo "VER=${TAG#v}" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-go@v6
+        with: { go-version: '${{ env.GO_VERSION }}' }
+      - uses: actions/setup-node@v4
+        with: { node-version: '${{ env.NODE_VERSION }}' }
+      - name: Install Wails + create-dmg
+        run: |
+          go install github.com/wailsapp/wails/v2/cmd/wails@${WAILS_VERSION}
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          brew install create-dmg
+      - name: Build universal .app + .dmg
+        working-directory: desktop
+        run: |
+          VER="${{ steps.ver.outputs.VER }}"
+          wails build -clean -platform darwin/universal \
+            -ldflags "-X 'github.com/ajramos/giztui/internal/version.Version=${VER}'"
+          DMG="build/bin/GizTUI-Desktop-${VER}-universal.dmg"
+          create-dmg --volname "GizTUI Desktop" --app-drop-link 480 170 \
+            --icon "GizTUI Desktop.app" 160 170 --window-size 640 360 \
+            "$DMG" "build/bin/GizTUI Desktop.app" \
+            || hdiutil create -volname "GizTUI Desktop" \
+                 -srcfolder "build/bin/GizTUI Desktop.app" -ov -format UDZO "$DMG"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: desktop-macos
+          path: desktop/build/bin/*.dmg
+          if-no-files-found: error
+
+  # ------------------------------------------------------------ Windows (NSIS)
+  windows:
+    runs-on: windows-latest
+    defaults: { run: { shell: bash } }
+    steps:
+      - uses: actions/checkout@v6
+      - id: ver
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then TAG="${{ github.event.inputs.version }}"; else TAG="${GITHUB_REF#refs/tags/}"; fi
+          echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
+          echo "VER=${TAG#v}" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-go@v6
+        with: { go-version: '${{ env.GO_VERSION }}' }
+      - uses: actions/setup-node@v4
+        with: { node-version: '${{ env.NODE_VERSION }}' }
+      - name: Install Wails + NSIS
+        run: |
+          go install github.com/wailsapp/wails/v2/cmd/wails@${WAILS_VERSION}
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          choco install nsis -y --no-progress
+      - name: Build .exe + NSIS installer
+        working-directory: desktop
+        run: |
+          VER="${{ steps.ver.outputs.VER }}"
+          "$(go env GOPATH)/bin/wails" build -clean -platform windows/amd64 -nsis \
+            -ldflags "-X 'github.com/ajramos/giztui/internal/version.Version=${VER}'"
+          cd build/bin
+          # Portable exe -> zip; NSIS installer -> renamed setup.exe
+          powershell -Command "Compress-Archive -Path 'GizTUI Desktop.exe' -DestinationPath 'GizTUI-Desktop-${{ steps.ver.outputs.VER }}-windows-amd64.zip' -Force"
+          mv *installer.exe "GizTUI-Desktop-${VER}-windows-amd64-setup.exe" 2>/dev/null || true
+      - uses: actions/upload-artifact@v7
+        with:
+          name: desktop-windows
+          path: |
+            desktop/build/bin/*-setup.exe
+            desktop/build/bin/*windows-amd64.zip
+          if-no-files-found: error
+
+  # -------------------------------------------------- Linux (AppImage + tar.gz)
+  linux:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+      - id: ver
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then TAG="${{ github.event.inputs.version }}"; else TAG="${GITHUB_REF#refs/tags/}"; fi
+          echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
+          echo "VER=${TAG#v}" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-go@v6
+        with: { go-version: '${{ env.GO_VERSION }}' }
+      - uses: actions/setup-node@v4
+        with: { node-version: '${{ env.NODE_VERSION }}' }
+      - name: Install webkit deps + Wails
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
+          go install github.com/wailsapp/wails/v2/cmd/wails@${WAILS_VERSION}
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - name: Build binary + tarball
+        working-directory: desktop
+        run: |
+          VER="${{ steps.ver.outputs.VER }}"
+          wails build -clean -platform linux/amd64 \
+            -ldflags "-X 'github.com/ajramos/giztui/internal/version.Version=${VER}'"
+          cd build/bin
+          # Wails names the binary from outputfilename ("GizTUI Desktop").
+          BIN="GizTUI Desktop"
+          cp "$BIN" giztui-desktop
+          tar -czf "GizTUI-Desktop-${VER}-linux-amd64.tar.gz" giztui-desktop
+      - name: Package AppImage (best-effort)
+        working-directory: desktop
+        continue-on-error: true
+        run: |
+          VER="${{ steps.ver.outputs.VER }}"
+          curl -sSL -o linuxdeploy https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          curl -sSL -o linuxdeploy-plugin-gtk https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh
+          chmod +x linuxdeploy linuxdeploy-plugin-gtk
+          mkdir -p AppDir/usr/bin
+          cp "build/bin/GizTUI Desktop" AppDir/usr/bin/giztui-desktop
+          cp build/appicon.png AppDir/giztui-desktop.png || true
+          cat > AppDir/giztui-desktop.desktop <<EOF
+          [Desktop Entry]
+          Type=Application
+          Name=GizTUI Desktop
+          Exec=giztui-desktop
+          Icon=giztui-desktop
+          Categories=Network;Email;
+          EOF
+          ./linuxdeploy --appdir AppDir --plugin gtk \
+            -d AppDir/giztui-desktop.desktop -i AppDir/giztui-desktop.png \
+            --output appimage
+          mv GizTUI_Desktop*.AppImage "build/bin/GizTUI-Desktop-${VER}-x86_64.AppImage" 2>/dev/null \
+            || mv *.AppImage "build/bin/GizTUI-Desktop-${VER}-x86_64.AppImage" 2>/dev/null || true
+      - uses: actions/upload-artifact@v7
+        with:
+          name: desktop-linux
+          path: |
+            desktop/build/bin/*.tar.gz
+            desktop/build/bin/*.AppImage
+          if-no-files-found: error
+
+  # ------------------------------------------ attach everything to the Release
+  publish:
+    needs: [macos, windows, linux]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - id: ver
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then TAG="${{ github.event.inputs.version }}"; else TAG="${GITHUB_REF#refs/tags/}"; fi
+          echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
+      - uses: actions/download-artifact@v6
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Checksums
+        run: (cd dist && sha256sum * > desktop-checksums.txt) || true
+      - name: Attach to release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.ver.outputs.TAG }}
+          files: dist/*
+          fail_on_unmatched_files: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -1,0 +1,33 @@
+# GizTUI Desktop (Wails) — build helpers.
+#
+# The desktop app is a nested Go module; these targets wrap the Wails CLI so you
+# don't have to remember the flags. Version is read from the repo-root VERSION
+# file and injected into internal/version.Version (what the app's Version() shows).
+
+WAILS_VERSION := v2.10.2
+VERSION := $(shell tr -d '[:space:]' < ../VERSION)
+LDFLAGS := -X 'github.com/ajramos/giztui/internal/version.Version=$(VERSION)'
+
+.PHONY: help deps build build-universal dmg dev clean
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+	  awk 'BEGIN {FS = ":.*?## "}; {printf "  %-16s %s\n", $$1, $$2}'
+
+deps: ## Install the Wails CLI (pinned)
+	go install github.com/wailsapp/wails/v2/cmd/wails@$(WAILS_VERSION)
+
+build: ## Build the app for the host platform
+	wails build -clean -ldflags "$(LDFLAGS)"
+
+build-universal: ## Build a macOS universal (Intel+ARM) app
+	wails build -clean -platform darwin/universal -ldflags "$(LDFLAGS)"
+
+dmg: ## Build the universal app and package a .dmg (macOS only)
+	./scripts/build-dmg.sh
+
+dev: ## Run the app in dev mode (hot reload)
+	wails dev
+
+clean: ## Remove build artifacts
+	rm -rf build/bin

--- a/desktop/scripts/build-dmg.sh
+++ b/desktop/scripts/build-dmg.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Build the GizTUI Desktop macOS app (universal) and package it into a .dmg.
+#
+# Runs on macOS only (needs Xcode command line tools + the Wails CLI). No extra
+# tooling required: the DMG is made with hdiutil, which ships with macOS. If
+# `create-dmg` is installed (brew install create-dmg) it is used instead for a
+# nicer window layout.
+#
+# Usage:  desktop/scripts/build-dmg.sh
+# Output: desktop/build/bin/GizTUI-Desktop-<version>-universal.dmg
+set -euo pipefail
+
+# --- locate the repo + read the version -------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DESKTOP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$DESKTOP_DIR/.." && pwd)"
+VERSION="$(tr -d '[:space:]' < "$REPO_ROOT/VERSION")"
+APP_NAME="GizTUI Desktop"
+APP="$DESKTOP_DIR/build/bin/$APP_NAME.app"
+DMG="$DESKTOP_DIR/build/bin/GizTUI-Desktop-$VERSION-universal.dmg"
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "error: a macOS .dmg can only be built on macOS." >&2
+  exit 1
+fi
+command -v wails >/dev/null 2>&1 || {
+  echo "error: the Wails CLI is not installed. Run:" >&2
+  echo "  go install github.com/wailsapp/wails/v2/cmd/wails@v2.10.2" >&2
+  exit 1
+}
+
+# --- build the universal .app ----------------------------------------------
+echo "==> Building $APP_NAME.app (universal) v$VERSION"
+( cd "$DESKTOP_DIR" && wails build -clean -platform darwin/universal \
+    -ldflags "-X 'github.com/ajramos/giztui/internal/version.Version=$VERSION'" )
+
+[[ -d "$APP" ]] || { echo "error: build did not produce $APP" >&2; exit 1; }
+
+# --- package the .dmg -------------------------------------------------------
+rm -f "$DMG"
+if command -v create-dmg >/dev/null 2>&1; then
+  echo "==> Packaging with create-dmg"
+  create-dmg \
+    --volname "$APP_NAME" \
+    --app-drop-link 480 170 \
+    --icon "$APP_NAME.app" 160 170 \
+    --window-size 640 360 \
+    "$DMG" "$APP"
+else
+  echo "==> Packaging with hdiutil (install create-dmg for a nicer layout)"
+  STAGING="$(mktemp -d)"
+  cp -R "$APP" "$STAGING/"
+  ln -s /Applications "$STAGING/Applications"
+  hdiutil create -volname "$APP_NAME" -srcfolder "$STAGING" \
+    -ov -format UDZO "$DMG"
+  rm -rf "$STAGING"
+fi
+
+echo "==> Built $DMG"

--- a/docs/DESKTOP_DISTRIBUTION.md
+++ b/docs/DESKTOP_DISTRIBUTION.md
@@ -3,9 +3,12 @@
 Design for building and distributing the **Wails desktop client** across macOS,
 Windows and Linux, and publishing it through package managers (Homebrew first).
 
-> Status: **design / proposal**. Nothing here is wired yet. The current
-> `release.yml` builds only the **TUI CLI** (`./cmd/giztui`) on Ubuntu; the
-> desktop app is not built anywhere.
+> Status: **Phase 1 implemented** (pending first-CI validation on macOS/Windows
+> runners). See `.github/workflows/release-desktop.yml` (the build matrix),
+> `desktop/scripts/build-dmg.sh` + `desktop/Makefile` (local macOS DMG), and
+> `packaging/homebrew/` (the cask + tap instructions). The macOS/Windows jobs
+> cannot be tested from the Linux dev container; expect one or two iterations to
+> shake out per-runner details. The CLI release (`release.yml`) is unchanged.
 
 ## 🎯 Goals
 

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,42 @@
+# Homebrew distribution for GizTUI Desktop
+
+GizTUI Desktop is a GUI app, so it ships as a **Homebrew Cask** (not a formula).
+Casks live in a **tap** — a separate repo the maintainer owns.
+
+## One-time setup
+
+1. Create a public repo named **`homebrew-giztui`** under `ajramos`
+   (the `homebrew-` prefix is required; the tap is then `ajramos/giztui`).
+2. Add `giztui-desktop.rb` (from this folder) at `Casks/giztui-desktop.rb`.
+
+Users then install with:
+
+```bash
+brew tap ajramos/giztui
+brew install --cask giztui-desktop
+```
+
+## Per-release bump
+
+After a release publishes `GizTUI-Desktop-<version>-universal.dmg`, update the
+cask's `version` and `sha256` in the tap.
+
+**Manual:**
+```bash
+VER=1.21.0
+URL="https://github.com/ajramos/giztui/releases/download/v$VER/GizTUI-Desktop-$VER-universal.dmg"
+SHA=$(curl -sSL "$URL" | shasum -a 256 | awk '{print $1}')
+# edit Casks/giztui-desktop.rb: version "$VER", sha256 "$SHA"
+```
+
+**Automated:** from the release workflow (or a small job in the tap), use
+[`dawidd6/action-homebrew-bump-cask`](https://github.com/dawidd6/action-homebrew-bump-cask)
+with a `GH_TAP_TOKEN` secret that can push to the tap repo. Deferred to phase 2
+in `docs/DESKTOP_DISTRIBUTION.md`.
+
+## Signing note
+
+The build is currently **unsigned**. `sha256 :no_check` in the cask lets it
+install without a pinned checksum; switch to a real `sha256` (as above) once you
+bump per release for a verified install. macOS notarization (phase 2) removes the
+Gatekeeper warning entirely.

--- a/packaging/homebrew/giztui-desktop.rb
+++ b/packaging/homebrew/giztui-desktop.rb
@@ -1,0 +1,30 @@
+# Homebrew Cask for GizTUI Desktop.
+#
+# This file belongs in a *tap* repo (a repo named `homebrew-giztui` owned by the
+# maintainer): copy it to `ajramos/homebrew-giztui` at `Casks/giztui-desktop.rb`.
+# Then users install with:
+#
+#   brew tap ajramos/giztui
+#   brew install --cask giztui-desktop
+#
+# On each release, bump `version` and `sha256` to match the new
+# GizTUI-Desktop-<version>-universal.dmg asset (see packaging/homebrew/README.md
+# for the auto-bump options). Until macOS notarization lands, the build is
+# unsigned; Homebrew strips the quarantine attribute on cask installs, so it
+# still opens without the manual right-click → Open dance.
+cask "giztui-desktop" do
+  version "1.21.0"
+  sha256 :no_check # replace with the DMG's sha256 for a pinned, verified install
+
+  url "https://github.com/ajramos/giztui/releases/download/v#{version}/GizTUI-Desktop-#{version}-universal.dmg"
+  name "GizTUI Desktop"
+  desc "Visual Gmail client (Wails) sharing the GizTUI service layer"
+  homepage "https://github.com/ajramos/giztui"
+
+  app "GizTUI Desktop.app"
+
+  zap trash: [
+    "~/Library/Application Support/giztui",
+    "~/Library/Logs/giztui",
+  ]
+end


### PR DESCRIPTION
# Pull Request

## 📋 **Description**

Phase 1 of the desktop distribution design (`docs/DESKTOP_DISTRIBUTION.md`):
build the Wails desktop client for macOS/Windows/Linux and ship installers.

- **`.github/workflows/release-desktop.yml`** — a per-OS build matrix (Wails can't
  cross-compile: native webview + CGO), triggered on `v*` tags and
  `workflow_dispatch`. Produces:
  - macOS: universal `.app` → **`.dmg`** (create-dmg, hdiutil fallback)
  - Windows: **NSIS** installer (`-setup.exe`) + portable `.zip`
  - Linux: `.tar.gz` + **best-effort AppImage** (non-blocking)
  - A `publish` job attaches everything (plus checksums) to the Release for the
    tag. Kept **separate from `release.yml`** so a desktop-packaging failure never
    blocks the CLI release.
- **`desktop/scripts/build-dmg.sh` + `desktop/Makefile`** — build a universal
  `.app` and a `.dmg` locally on a Mac (`make deps && make dmg`).
- **`packaging/homebrew/`** — a Homebrew **cask** + tap setup/bump instructions
  for `brew install --cask giztui-desktop`.

Unsigned in phase 1 (Gatekeeper/SmartScreen warn); notarization/signing is phase 2.

> ⚠️ The macOS/Windows/Linux Wails builds **could not be exercised from the Linux
> dev container** — YAML/shell/Makefile are validated, but the runner steps
> (NSIS installer name, webkit dev-package, AppImage tooling) may need one or two
> iterations on the first CI run. Nothing here touches the existing build or the
> CLI release path.

## 🏗️ **Architecture Compliance Checklist**

### ✅ **Service Layer**
- [x] N/A — packaging/CI only; no application code changed

### ✅ **Error Handling**
- [x] N/A — no runtime code

### ✅ **Thread Safety**
- [x] N/A

### ✅ **UI Components**
- [x] N/A

### ✅ **Testing**
- [x] Workflow YAML validated; `build-dmg.sh` passes `bash -n`; `desktop/Makefile`
  parses. Runner behavior validated on first CI run (can't build macOS/Windows here).

## 🧪 **Testing**
- [x] `make build` / `make test` unaffected (no Go/app changes)
- [x] Static validation of the new YAML/script/Makefile
- [ ] First CI run of `release-desktop.yml` on macOS/Windows/Linux — pending merge

## 📝 **Related Issues**
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU)_