### PR TITLE
ci(desktop): make release-desktop matrix produce all installers

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -50,6 +50,10 @@ jobs:
         working-directory: desktop
         run: |
           VER="${{ steps.ver.outputs.VER }}"
+          # Build the frontend first: wails generates Go bindings (which compile
+          # main.go's //go:embed all:frontend/dist) before it builds the frontend,
+          # so on a clean checkout dist must already exist.
+          ( cd frontend && (npm ci || npm install) && npm run build )
           wails build -clean -platform darwin/universal \
             -ldflags "-X 'github.com/ajramos/giztui/internal/version.Version=${VER}'"
           DMG="build/bin/GizTUI-Desktop-${VER}-universal.dmg"
@@ -84,11 +88,17 @@ jobs:
           go install github.com/wailsapp/wails/v2/cmd/wails@${WAILS_VERSION}
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
           choco install nsis -y --no-progress
+          # choco deploys makensis to "C:\Program Files (x86)\NSIS" but does not
+          # add it to PATH; `wails build -nsis` shells out to makensis, so put it
+          # on PATH explicitly (both common locations) or no installer is made.
+          echo "C:\Program Files (x86)\NSIS" >> "$GITHUB_PATH"
+          echo "C:\Program Files\NSIS" >> "$GITHUB_PATH"
       - name: Build .exe + NSIS installer
         working-directory: desktop
         run: |
           VER="${{ steps.ver.outputs.VER }}"
-          "$(go env GOPATH)/bin/wails" build -clean -platform windows/amd64 -nsis \
+          ( cd frontend && (npm ci || npm install) && npm run build )
+          wails build -clean -platform windows/amd64 -nsis \
             -ldflags "-X 'github.com/ajramos/giztui/internal/version.Version=${VER}'"
           cd build/bin
           # Portable exe -> zip; NSIS installer -> renamed setup.exe
@@ -119,13 +129,16 @@ jobs:
       - name: Install webkit deps + Wails
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
+          # imagemagick: linuxdeploy rejects the 1024x1024 appicon.png (max 512),
+          # so we downscale it to 512x512 before building the AppImage.
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev imagemagick
           go install github.com/wailsapp/wails/v2/cmd/wails@${WAILS_VERSION}
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - name: Build binary + tarball
         working-directory: desktop
         run: |
           VER="${{ steps.ver.outputs.VER }}"
+          ( cd frontend && (npm ci || npm install) && npm run build )
           wails build -clean -platform linux/amd64 \
             -ldflags "-X 'github.com/ajramos/giztui/internal/version.Version=${VER}'"
           cd build/bin
@@ -138,12 +151,18 @@ jobs:
         continue-on-error: true
         run: |
           VER="${{ steps.ver.outputs.VER }}"
+          # linuxdeploy + appimagetool are themselves AppImages; extract-and-run
+          # avoids needing FUSE on the runner.
+          export APPIMAGE_EXTRACT_AND_RUN=1
           curl -sSL -o linuxdeploy https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
           curl -sSL -o linuxdeploy-plugin-gtk https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh
           chmod +x linuxdeploy linuxdeploy-plugin-gtk
           mkdir -p AppDir/usr/bin
           cp "build/bin/GizTUI Desktop" AppDir/usr/bin/giztui-desktop
-          cp build/appicon.png AppDir/giztui-desktop.png || true
+          # linuxdeploy only accepts icon resolutions up to 512x512; appicon.png
+          # is 1024x1024, so resize it (fall back to a plain copy if convert fails).
+          convert build/appicon.png -resize 512x512 AppDir/giztui-desktop.png \
+            || cp build/appicon.png AppDir/giztui-desktop.png || true
           cat > AppDir/giztui-desktop.desktop <<EOF
           [Desktop Entry]
           Type=Application

--- a/desktop/scripts/build-dmg.sh
+++ b/desktop/scripts/build-dmg.sh
@@ -30,6 +30,12 @@ command -v wails >/dev/null 2>&1 || {
 }
 
 # --- build the universal .app ----------------------------------------------
+# Build the frontend first: wails generates Go bindings (which compile
+# main.go's //go:embed all:frontend/dist) before it builds the frontend, so on a
+# fresh clone dist must already exist.
+echo "==> Building frontend"
+( cd "$DESKTOP_DIR/frontend" && npm install && npm run build )
+
 echo "==> Building $APP_NAME.app (universal) v$VERSION"
 ( cd "$DESKTOP_DIR" && wails build -clean -platform darwin/universal \
     -ldflags "-X 'github.com/ajramos/giztui/internal/version.Version=$VERSION'" )


### PR DESCRIPTION
## 📋 Description

CI/packaging-only fix. The `release-desktop.yml` matrix (added in #56) built green but silently produced only a subset of artifacts on a real `v*` tag. Three fixes so a tag builds the **full** set of desktop installers:

- **Frontend pre-build (all OS jobs + `build-dmg.sh`)** — `wails build` generates Go bindings that compile `main.go`'s `//go:embed all:frontend/dist` **before** it builds the frontend, so on a clean checkout `dist` must already exist. Without this, bindings generation failed with `pattern all:frontend/dist: no matching files found`.
- **Windows NSIS** — `choco install nsis` deploys `makensis` to `C:\Program Files (x86)\NSIS` but does not add it to PATH, so `wails build -nsis` couldn't find it and produced only the portable zip (no `setup.exe`). Now NSIS is added to `GITHUB_PATH`.
- **Linux AppImage** — `linuxdeploy` rejects icons above 512×512, and `appicon.png` is 1024×1024, so the icon deploy failed and no AppImage was built. Install `imagemagick` and downscale to 512×512; also set `APPIMAGE_EXTRACT_AND_RUN=1` so the `linuxdeploy`/`appimagetool` AppImages run without FUSE on the runner.

**Verified on the v1.21.0 release** (matrix run on the fix): the `.dmg`, Windows `setup.exe` + portable `.zip`, and Linux `.AppImage` + `.tar.gz` are all attached.

## 🏗️ Architecture Compliance Checklist

No application code changed — this touches only `.github/workflows/release-desktop.yml` and `desktop/scripts/build-dmg.sh`.

### ✅ Service Layer
- [ ] N/A — no service/business logic touched

### ✅ Error Handling
- [ ] N/A — no user-facing code

### ✅ Thread Safety
- [ ] N/A — no app state touched

### ✅ UI Components
- [ ] N/A — no UI touched

### ✅ Testing
- [ ] N/A — CI workflow change

## 🧪 Testing
- [x] Validated on a live matrix run (workflow_dispatch on the fix): all installers produced and attached to the v1.21.0 release
- [x] No regressions to the CLI release (`release.yml` untouched)

## 📝 Related Issues
Follow-up to #56.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU)_