### PR TITLE
ci(desktop): auto-bump the Homebrew cask on release

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -208,3 +208,62 @@ jobs:
           fail_on_unmatched_files: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ------------------------------------------------------ Homebrew cask auto-bump
+  # Bumps version + sha256 in the tap (ajramos/homebrew-giztui, Casks/
+  # giztui-desktop.rb) to match the new universal .dmg, so `brew upgrade` picks up
+  # the release with no manual step. Requires a HOMEBREW_TAP_TOKEN secret (a PAT
+  # with contents:write on the tap repo); if it is absent the job no-ops so the
+  # release itself never fails.
+  homebrew:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - id: ver
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then TAG="${{ github.event.inputs.version }}"; else TAG="${GITHUB_REF#refs/tags/}"; fi
+          echo "VER=${TAG#v}" >> "$GITHUB_OUTPUT"
+      - name: Download macOS .dmg
+        uses: actions/download-artifact@v6
+        with:
+          name: desktop-macos
+          path: dist
+      - name: Update the tap cask
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VER: ${{ steps.ver.outputs.VER }}
+        run: |
+          if [ -z "$TAP_TOKEN" ]; then
+            echo "::warning::HOMEBREW_TAP_TOKEN not set — skipping cask auto-bump. Add the secret (a PAT with contents:write on ajramos/homebrew-giztui) to enable it."
+            exit 0
+          fi
+          DMG="dist/GizTUI-Desktop-${VER}-universal.dmg"
+          if [ ! -f "$DMG" ]; then echo "::warning::$DMG not found — skipping cask bump."; exit 0; fi
+          SHA="$(sha256sum "$DMG" | cut -d' ' -f1)"
+          git clone --depth 1 "https://x-access-token:${TAP_TOKEN}@github.com/ajramos/homebrew-giztui.git" tap
+          mkdir -p tap/Casks
+          cat > tap/Casks/giztui-desktop.rb <<EOF
+          cask "giztui-desktop" do
+            version "${VER}"
+            sha256 "${SHA}"
+
+            url "https://github.com/ajramos/giztui/releases/download/v#{version}/GizTUI-Desktop-#{version}-universal.dmg"
+            name "GizTUI Desktop"
+            desc "Visual Gmail client (Wails) sharing the GizTUI service layer"
+            homepage "https://github.com/ajramos/giztui"
+
+            app "GizTUI Desktop.app"
+
+            zap trash: [
+              "~/Library/Application Support/giztui",
+              "~/Library/Logs/giztui",
+            ]
+          end
+          EOF
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Casks/giztui-desktop.rb
+          git commit -m "giztui-desktop ${VER}" || { echo "cask already up to date"; exit 0; }
+          git push
+          echo "Bumped tap cask to ${VER} (sha256 ${SHA})"

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -30,21 +30,24 @@ brew install --cask giztui-desktop
 
 ## Per-release bump
 
-After a release publishes `GizTUI-Desktop-<version>-universal.dmg`, update the
-cask's `version` and `sha256` in the tap.
+**Automated (default).** The `homebrew` job in `.github/workflows/release-desktop.yml`
+runs on every tagged release: it downloads the freshly built
+`GizTUI-Desktop-<version>-universal.dmg`, computes its `sha256`, and pushes an
+updated `Casks/giztui-desktop.rb` (pinned `version` + `sha256`) to the tap repo
+`ajramos/homebrew-giztui`. So `brew upgrade --cask giztui-desktop` just works.
 
-**Manual:**
+**One-time setup:** add a repository secret **`HOMEBREW_TAP_TOKEN`** to
+`ajramos/giztui` — a fine-grained PAT (or classic token with `repo`) that has
+**contents: write** on `ajramos/homebrew-giztui`. Without it the job logs a
+warning and skips; the release itself never fails.
+
+**Manual fallback** (e.g. the very first tap seed, or the secret isn't set yet):
 ```bash
-VER=1.21.0
+VER=1.22.0
 URL="https://github.com/ajramos/giztui/releases/download/v$VER/GizTUI-Desktop-$VER-universal.dmg"
 SHA=$(curl -sSL "$URL" | shasum -a 256 | awk '{print $1}')
 # edit Casks/giztui-desktop.rb: version "$VER", sha256 "$SHA"
 ```
-
-**Automated:** from the release workflow (or a small job in the tap), use
-[`dawidd6/action-homebrew-bump-cask`](https://github.com/dawidd6/action-homebrew-bump-cask)
-with a `GH_TAP_TOKEN` secret that can push to the tap repo. Deferred to phase 2
-in `docs/DESKTOP_DISTRIBUTION.md`.
 
 ## Signing note
 

--- a/packaging/homebrew/giztui-desktop.rb
+++ b/packaging/homebrew/giztui-desktop.rb
@@ -7,14 +7,15 @@
 #   brew tap ajramos/giztui
 #   brew install --cask giztui-desktop
 #
-# On each release, bump `version` and `sha256` to match the new
-# GizTUI-Desktop-<version>-universal.dmg asset (see packaging/homebrew/README.md
-# for the auto-bump options). Until macOS notarization lands, the build is
-# unsigned; Homebrew strips the quarantine attribute on cask installs, so it
-# still opens without the manual right-click → Open dance.
+# This is the source-of-truth template. On a tagged release the
+# release-desktop.yml `homebrew` job regenerates the tap's copy with the new
+# `version` and the real `sha256` of the universal .dmg (needs the
+# HOMEBREW_TAP_TOKEN secret — see packaging/homebrew/README.md). Until macOS
+# notarization lands the build is unsigned; Homebrew strips the quarantine
+# attribute on cask installs, so it still opens without the right-click → Open dance.
 cask "giztui-desktop" do
-  version "1.21.0"
-  sha256 :no_check # replace with the DMG's sha256 for a pinned, verified install
+  version "1.22.0"
+  sha256 :no_check # the tap copy is pinned to the DMG's sha256 by CI
 
   url "https://github.com/ajramos/giztui/releases/download/v#{version}/GizTUI-Desktop-#{version}-universal.dmg"
   name "GizTUI Desktop"


### PR DESCRIPTION
## 📋 **Description**

Automates the Homebrew cask bump that was previously manual on every release.

A new `homebrew` job in `release-desktop.yml` runs after `publish`: it downloads the freshly built `GizTUI-Desktop-<version>-universal.dmg`, computes its `sha256`, and pushes an updated `Casks/giztui-desktop.rb` (pinned `version` + `sha256`) to the tap repo `ajramos/homebrew-giztui`. So `brew upgrade --cask giztui-desktop` picks up each release with no manual step.

**One-time setup required:** add a repo secret **`HOMEBREW_TAP_TOKEN`** to `ajramos/giztui` — a PAT with **contents: write** on `ajramos/homebrew-giztui`. If the secret is absent the job logs a warning and skips, so the release itself never fails.

Also bumps the cask template to 1.22.0 and rewrites the packaging README's per-release section to document the automation + fallback.

## 🧪 **Testing**
- [x] `release-desktop.yml` parses as valid YAML (5 jobs: macos, windows, linux, publish, homebrew)
- [x] Job is fail-safe: no-ops with a warning when `HOMEBREW_TAP_TOKEN` is unset
- [ ] End-to-end verified on the next tagged release (this one, v1.22.0, was tagged before the job existed — it applies from the next release, or a workflow re-run once the secret is set)

## 📝 **Related Issues**
Follow-up to the v1.22.0 release packaging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU)_