### PR TITLE
chore(desktop): clear pre-existing pkg/desktop lint findings

### DIFF
--- a/pkg/desktop/api.go
+++ b/pkg/desktop/api.go
@@ -224,9 +224,9 @@ func (a *API) GetMessage(ctx context.Context, id string) (*MessageDetail, error)
 		Labels:    userLabels(msg.Labels),
 	}
 	if msg.Message != nil {
-		detail.ID = msg.Message.Id
-		detail.ThreadID = msg.Message.ThreadId
-		detail.Unread = containsLabel(msg.Message.LabelIds, "UNREAD")
+		detail.ID = msg.Id
+		detail.ThreadID = msg.ThreadId
+		detail.Unread = containsLabel(msg.LabelIds, "UNREAD")
 	}
 	return detail, nil
 }

--- a/pkg/desktop/credentials_test.go
+++ b/pkg/desktop/credentials_test.go
@@ -52,6 +52,7 @@ func TestInstallCredentials(t *testing.T) {
 	if got != dest {
 		t.Fatalf("dest = %q, want %q", got, dest)
 	}
+	// #nosec G304 -- test reads back the file it just wrote under a temp dir
 	data, err := os.ReadFile(dest)
 	if err != nil {
 		t.Fatalf("copied file not readable: %v", err)

--- a/pkg/desktop/logging.go
+++ b/pkg/desktop/logging.go
@@ -30,6 +30,7 @@ func SetupFileLogging() (string, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return "", err
 	}
+	// #nosec G304 -- path is the app's own log file under the config dir, not external input
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return "", err

--- a/pkg/desktop/session.go
+++ b/pkg/desktop/session.go
@@ -444,6 +444,7 @@ func InstallCredentials(opts Options, srcPath string) (string, error) {
 	if srcPath == "" {
 		return "", fmt.Errorf("no file selected")
 	}
+	// #nosec G304 -- srcPath is the credentials file the user explicitly picked to import
 	data, err := os.ReadFile(srcPath)
 	if err != nil {
 		return "", fmt.Errorf("could not read %s: %w", srcPath, err)


### PR DESCRIPTION
## 📋 **Description**

Cleans up the 6 pre-existing golangci-lint findings in `pkg/desktop` (they didn't fail CI, which runs in new-issues-only mode, but they cluttered `make pre-commit-check`).

- **staticcheck QF1008** (`api.go` ×3): drop the redundant embedded `.Message` selector — `msg.Id` / `msg.ThreadId` / `msg.LabelIds` promote through the embedded field. The `if msg.Message != nil` guard stays.
- **gosec G304** (`logging.go`, `session.go`, `credentials_test.go`): annotate the three file reads/opens with a justified `// #nosec G304` — they're the app's own log path, the credentials file the user explicitly picked to import, and a test temp file respectively; none is untrusted external input.

## 🧪 **Testing**
- [x] `golangci-lint run ./pkg/desktop/...` → **0 issues**
- [x] `make pre-commit-check` → **All checks passed** (fmt + vet + lint + tests)
- [x] `go build ./pkg/desktop/ && go test ./pkg/desktop/` green
- [x] No behavior change (selector promotion + lint annotations only)

## 📝 **Related Issues**
Follow-up tidy after the v1.22.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU)_