### PR TITLE
refactor(desktop): test harness + extract pure logic from App.tsx (F0–F2)

### DIFF
--- a/desktop/frontend/package-lock.json
+++ b/desktop/frontend/package-lock.json
@@ -16,9 +16,32 @@
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
+        "jsdom": "^25.0.1",
         "typescript": "^5.6.3",
-        "vite": "^5.4.11"
+        "vite": "^5.4.11",
+        "vitest": "^2.1.9"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -300,6 +323,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1208,6 +1346,146 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.43",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
@@ -1255,6 +1533,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001806",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
@@ -1276,10 +1578,71 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1289,6 +1652,20 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1308,6 +1685,33 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dompurify": {
       "version": "3.4.12",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
@@ -1317,12 +1721,96 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.393",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
       "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1373,6 +1861,43 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1388,6 +1913,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1398,11 +1933,207 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -1442,6 +2173,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1450,6 +2188,49 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/ms": {
@@ -1488,6 +2269,43 @@
         "node": ">=18"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1522,6 +2340,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react": {
@@ -1604,6 +2432,33 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -1623,6 +2478,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1631,6 +2493,117 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/typescript": {
@@ -1737,6 +2710,212 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "dompurify": "^3.4.12",
@@ -17,7 +19,9 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
+    "jsdom": "^25.0.1",
     "typescript": "^5.6.3",
-    "vite": "^5.4.11"
+    "vite": "^5.4.11",
+    "vitest": "^2.1.9"
   }
 }

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -51,6 +51,7 @@ import {
   formatFull,
   formatSize,
 } from "./format";
+import { replyInit, replyAllInit, forwardInit } from "./compose";
 import {
   buildMoveTargets,
   applyPlanMove,
@@ -1787,28 +1788,6 @@ export default function App() {
     if (aiEnabled) void summarize(id, true);
   }, [summarize, runPrompt, touchUp, aiEnabled]);
 
-  const replyInit = (d: MessageDetail): ComposeInit => ({
-    mode: "reply",
-    originalId: d.id,
-    to: d.from,
-  });
-
-  // Reply-all: reply threaded, adding the original To/Cc recipients as Cc.
-  const replyAllInit = (d: MessageDetail): ComposeInit => {
-    const extra = [d.to, d.cc]
-      .filter(Boolean)
-      .join(", ")
-      .split(",")
-      .map((s) => s.trim())
-      .filter((s) => s && !d.from.includes(s));
-    return {
-      mode: "reply",
-      originalId: d.id,
-      to: d.from,
-      cc: [...new Set(extra)].join(", "),
-    };
-  };
-
   const saveMessage = useCallback(
     (id: string) => {
       void backend
@@ -2842,12 +2821,6 @@ export default function App() {
       resetZoom,
     ],
   );
-
-  const forwardInit = (d: MessageDetail): ComposeInit => ({
-    mode: "new",
-    subject: d.subject.startsWith("Fwd:") ? d.subject : `Fwd: ${d.subject}`,
-    body: `\n\n---------- Forwarded message ----------\nFrom: ${d.from}\nDate: ${d.date}\nSubject: ${d.subject}\nTo: ${d.to}\n\n${d.plainText}`,
-  });
 
   const downloadAttachment = useCallback(
     async (att: Attachment) => {

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -39,6 +39,19 @@ import AttachmentsPicker from "./AttachmentsPicker";
 import Markdown from "./Markdown";
 import AiPanel from "./AiPanel";
 import {
+  displayName,
+  matchesCombo,
+  emailAddr,
+  labelForAction,
+  formatICSDate,
+  mixHex,
+  cleanSubject,
+  countMatches,
+  formatDate,
+  formatFull,
+  formatSize,
+} from "./format";
+import {
   buildMoveTargets,
   applyPlanMove,
   sortPlanCategories,
@@ -5603,145 +5616,3 @@ export default function App() {
 
 // --- helpers -----------------------------------------------------------------
 
-function displayName(from: string): string {
-  const m = from.match(/^\s*"?([^"<]+?)"?\s*</);
-  if (m) return m[1].trim();
-  return from.split("@")[0] || from;
-}
-
-// matchesCombo reports whether a keyboard event matches a TUI-style modifier
-// combo like "ctrl+f" or "ctrl+shift+p". Ctrl and Cmd are treated as
-// interchangeable so a config's "ctrl+f" also fires on macOS's Cmd+F. Only
-// combos that include a modifier are matched — a bare key returns false so it
-// never hijacks normal typing/actions.
-function matchesCombo(e: KeyboardEvent, combo: string): boolean {
-  const parts = combo.toLowerCase().split("+");
-  const key = parts[parts.length - 1];
-  const wantCtrlOrMeta = parts.includes("ctrl") || parts.includes("cmd") || parts.includes("meta");
-  const wantShift = parts.includes("shift");
-  const wantAlt = parts.includes("alt") || parts.includes("option");
-  if (!wantCtrlOrMeta && !wantAlt) return false; // require a modifier
-  if (wantCtrlOrMeta !== (e.ctrlKey || e.metaKey)) return false;
-  if (wantAlt !== e.altKey) return false;
-  if (wantShift !== e.shiftKey) return false;
-  return e.key.toLowerCase() === key;
-}
-
-function emailAddr(from: string): string {
-  const m = from.match(/<([^>]+)>/);
-  return m ? m[1] : from;
-}
-
-// labelForAction is the present-participle verb shown while a bulk action runs.
-function labelForAction(action: string): string {
-  switch (action) {
-    case "archive":
-      return "Archiving";
-    case "trash":
-      return "Trashing";
-    case "read":
-      return "Marking read";
-    case "unread":
-      return "Marking unread";
-    default:
-      return "Working on";
-  }
-}
-
-// formatICSDate turns an iCalendar date-time (optionally with a ;TZID= prefix,
-// e.g. "20260720T150000" or ";TZID=Europe/Madrid:20260720T150000") into a
-// human-readable local string.
-function formatICSDate(raw: string): string {
-  const v = raw.includes(":") ? raw.slice(raw.lastIndexOf(":") + 1) : raw;
-  const m = v.match(/^(\d{4})(\d{2})(\d{2})(?:T(\d{2})(\d{2})(\d{2})?Z?)?/);
-  if (!m) return raw;
-  const [, y, mo, d, hh = "00", mm = "00"] = m;
-  const dt = new Date(
-    Number(y),
-    Number(mo) - 1,
-    Number(d),
-    Number(hh),
-    Number(mm),
-  );
-  if (Number.isNaN(dt.getTime())) return raw;
-  return dt.toLocaleString([], {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
-
-// mixHex blends hex color `a` toward `b` by t∈[0,1]. Falls back to `a` when
-// either isn't a parseable #rgb / #rrggbb string, so theme mapping never breaks.
-function mixHex(a: string, b: string, t: number): string {
-  const parse = (h: string): [number, number, number] | null => {
-    let s = h.trim().replace(/^#/, "");
-    if (s.length === 3) s = s.replace(/(.)/g, "$1$1");
-    if (s.length !== 6 || /[^0-9a-fA-F]/.test(s)) return null;
-    return [
-      parseInt(s.slice(0, 2), 16),
-      parseInt(s.slice(2, 4), 16),
-      parseInt(s.slice(4, 6), 16),
-    ];
-  };
-  const ca = parse(a);
-  const cb = parse(b);
-  if (!ca || !cb) return a;
-  const mix = (x: number, y: number) =>
-    Math.round(x + (y - x) * t)
-      .toString(16)
-      .padStart(2, "0");
-  return `#${mix(ca[0], cb[0])}${mix(ca[1], cb[1])}${mix(ca[2], cb[2])}`;
-}
-
-// cleanSubject strips Re:/Fwd: prefixes so a subject search matches the thread.
-function cleanSubject(subject: string): string {
-  return subject.replace(/^(\s*(re|fwd|fw)\s*:\s*)+/i, "").trim() || subject;
-}
-
-// countMatches returns how many times query occurs in text (case-insensitive).
-function countMatches(text: string, query: string): number {
-  if (!query) return 0;
-  const q = query.toLowerCase();
-  const t = text.toLowerCase();
-  let n = 0;
-  let i = t.indexOf(q);
-  while (i !== -1) {
-    n++;
-    i = t.indexOf(q, i + q.length);
-  }
-  return n;
-}
-
-function formatDate(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
-  const mins = Math.floor((Date.now() - d.getTime()) / 60000);
-  if (mins < 1) return "now";
-  if (mins < 60) return `${mins}m`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `${hours}h`;
-  const days = Math.floor(hours / 24);
-  if (days < 7) return `${days}d`;
-  return d.toLocaleDateString([], { month: "short", day: "numeric" });
-}
-
-function formatFull(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
-  return d.toLocaleString();
-}
-
-function formatSize(bytes: number): string {
-  if (bytes <= 0) return "";
-  const units = ["B", "KB", "MB", "GB"];
-  let n = bytes;
-  let u = 0;
-  while (n >= 1024 && u < units.length - 1) {
-    n /= 1024;
-    u++;
-  }
-  return `${n.toFixed(u === 0 ? 0 : 1)} ${units[u]}`;
-}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -64,90 +64,13 @@ import HtmlBody from "./HtmlBody";
 import PlainBody from "./PlainBody";
 import HighlightedText from "./HighlightedText";
 import Help from "./Help";
-import CommandBar, { type CommandDef } from "./CommandBar";
+import CommandBar from "./CommandBar";
+import { COMMANDS, parseCommand } from "./commands";
 import MoreMenu from "./MoreMenu";
 import { useListNav } from "./useListNav";
 import { Icon, IconBtn } from "./Icons";
 
 const PAGE_SIZE = 50;
-
-// Command palette entries (`:` command mode), mirroring the TUI's command set.
-const COMMANDS: CommandDef[] = [
-  { names: ["search", "s"], desc: "Gmail search", arg: "<query>" },
-  { names: ["unread", "u"], desc: "Show unread only" },
-  { names: ["advanced", "adv"], desc: "Advanced search builder" },
-  { names: ["local"], desc: "Toggle local filter / Gmail search" },
-  { names: ["stats", "usage"], desc: "AI prompt usage stats" },
-  { names: ["config", "cfg"], desc: "Show configuration" },
-  { names: ["cache"], desc: "Clear AI caches" },
-  { names: ["archive", "a"], desc: "Archive message" },
-  { names: ["trash", "d"], desc: "Trash message" },
-  { names: ["undo"], desc: "Undo last action" },
-  { names: ["read"], desc: "Mark read" },
-  { names: ["markunread"], desc: "Mark unread" },
-  { names: ["toggle-read", "t"], desc: "Toggle read / unread" },
-  { names: ["labels", "l"], desc: "Manage labels" },
-  { names: ["compose", "c", "new"], desc: "New message" },
-  { names: ["reply", "r"], desc: "Reply" },
-  { names: ["replyall", "reply-all", "ra"], desc: "Reply all" },
-  { names: ["forward", "f"], desc: "Forward" },
-  { names: ["refresh"], desc: "Refresh inbox" },
-  { names: ["drafts", "dr"], desc: "Drafts" },
-  { names: ["links", "link"], desc: "Links in message" },
-  { names: ["save"], desc: "Save to file" },
-  { names: ["save-raw", "saveraw"], desc: "Save raw .eml" },
-  { names: ["rsvp"], desc: "Open RSVP picker for invite" },
-  { names: ["accept"], desc: "RSVP: accept invite" },
-  { names: ["tentative", "maybe"], desc: "RSVP: tentative" },
-  { names: ["decline"], desc: "RSVP: decline invite" },
-  { names: ["autorefresh", "arr"], desc: "Toggle inbox auto-refresh" },
-  { names: ["summarize", "sum", "summary"], desc: "AI summary" },
-  { names: ["prompt", "pr", "p"], desc: "Apply a prompt" },
-  { names: ["prompts", "prompt-new"], desc: "Manage prompts" },
-  { names: ["suggest"], desc: "Suggest labels (AI)" },
-  { names: ["obsidian", "obs"], desc: "Send to Obsidian" },
-  { names: ["slack", "sl"], desc: "Forward to Slack" },
-  { names: ["gmail", "web", "open-web", "o"], desc: "Open in Gmail" },
-  { names: ["threads", "thr"], desc: "Toggle conversation view" },
-  { names: ["expand-all", "expand", "flatten", "flat"], desc: "Expand all in thread" },
-  { names: ["collapse-all", "collapse"], desc: "Collapse all in thread" },
-  { names: ["thread-summary", "th-sum"], desc: "Summarize thread (AI)" },
-  { names: ["inbox", "i"], desc: "Back to inbox" },
-  { names: ["archived", "b", "arch-search"], desc: "Archived messages" },
-  { names: ["markdown", "md"], desc: "Toggle HTML / text" },
-  { names: ["images", "remote", "img"], desc: "Load / block remote images" },
-  { names: ["images-always", "always-images", "imgall"], desc: "Always load remote images (on/off)" },
-  { names: ["load", "more", "next"], desc: "Load more messages" },
-  { names: ["attachments", "attach"], desc: "Focus attachments" },
-  { names: ["accounts", "acc"], desc: "Switch account" },
-  { names: ["label", "lbl"], desc: "Add label by name", arg: "<name>" },
-  { names: ["select", "sel"], desc: "Bulk-select rows", arg: "all|none|<n|a-b>" },
-  { names: ["goto", "g"], desc: "Go to row", arg: "[n]" },
-  { names: ["bottom", "end", "$"], desc: "Go to last row" },
-  { names: ["queries"], desc: "Saved searches" },
-  { names: ["savequery", "save-query", "sq"], desc: "Save current search" },
-  { names: ["plan", "actionplan", "action-plan", "ap"], desc: "AI inbox action plan", arg: "[rules|prompt]" },
-  { names: ["rules", "ru"], desc: "Deterministic rules manager", arg: "[run|plan]" },
-  { names: ["rp"], desc: "Run deterministic rules (:rules plan)" },
-  { names: ["move", "mv"], desc: "Move to folder", arg: "[label]" },
-  { names: ["draft", "replyai"], desc: "Draft reply (AI)" },
-  { names: ["find"], desc: "Find in message", arg: "<text>" },
-  { names: ["from"], desc: "Search from this sender" },
-  { names: ["to"], desc: "Search to this recipient" },
-  { names: ["subject"], desc: "Search this subject" },
-  { names: ["headers", "toggle-headers"], desc: "Toggle headers" },
-  { names: ["toolbar"], desc: "Show/hide reader toolbar" },
-  { names: ["zoom-in", "zi"], desc: "Bigger UI text (Cmd/Ctrl +)" },
-  { names: ["zoom-out", "zo"], desc: "Smaller UI text (Cmd/Ctrl -)" },
-  { names: ["zoom-reset"], desc: "Reset UI zoom (Cmd/Ctrl 0)" },
-  { names: ["zoom"], desc: "Set UI zoom", arg: "<0.6-2.4>" },
-  { names: ["touch-up", "touchup"], desc: "Reformat message with AI" },
-  { names: ["theme", "th"], desc: "Change theme", arg: "[name]" },
-  { names: ["regenerate", "regen"], desc: "Regenerate the open AI panel (summary/prompt)" },
-  { names: ["dismiss", "close-ai"], desc: "Close the open AI panel" },
-  { names: ["quit", "q", "exit"], desc: "Quit GizTUI" },
-  { names: ["help", "h"], desc: "Keyboard shortcuts" },
-];
 
 export default function App() {
   const [account, setAccount] = useState("");
@@ -2332,9 +2255,7 @@ export default function App() {
   // Command palette dispatcher (`:` command mode).
   const executeCommand = useCallback(
     (input: string) => {
-      const parts = input.trim().split(/\s+/);
-      const cmd = (parts[0] || "").toLowerCase();
-      const arg = parts.slice(1).join(" ");
+      const { cmd, arg } = parseCommand(input);
       const d = detail;
       // Move the cursor/preview to a 1-based row (shared by :g, :$ and :N).
       const gotoRow = (n1: number) => {

--- a/desktop/frontend/src/CommandBar.tsx
+++ b/desktop/frontend/src/CommandBar.tsx
@@ -1,10 +1,7 @@
 import { useMemo, useState } from "react";
+import { type CommandDef, filterCommands, resolveEnter } from "./commands";
 
-export interface CommandDef {
-  names: string[]; // first is canonical, rest are aliases
-  desc: string;
-  arg?: string; // placeholder hint when the command takes an argument
-}
+export type { CommandDef };
 
 export default function CommandBar({
   commands,
@@ -18,13 +15,10 @@ export default function CommandBar({
   const [input, setInput] = useState("");
   const [active, setActive] = useState(0);
 
-  const matches = useMemo(() => {
-    const word = input.trim().split(/\s+/)[0]?.toLowerCase() ?? "";
-    if (!word) return commands;
-    return commands.filter((c) =>
-      c.names.some((n) => n.toLowerCase().startsWith(word)),
-    );
-  }, [commands, input]);
+  const matches = useMemo(
+    () => filterCommands(commands, input),
+    [commands, input],
+  );
 
   const submit = (value: string) => {
     const v = value.trim();
@@ -56,17 +50,9 @@ export default function CommandBar({
             if (matches[active]) setInput(matches[active].names[0] + " ");
           } else if (e.key === "Enter") {
             e.preventDefault();
-            // If the typed word matches a command exactly, run the input as-is
-            // (keeps arguments); otherwise run the highlighted suggestion.
-            const word = input.trim().split(/\s+/)[0]?.toLowerCase() ?? "";
-            const exact = commands.find((c) =>
-              c.names.some((n) => n.toLowerCase() === word),
-            );
-            if (exact) submit(input);
-            else if (matches[active]) submit(matches[active].names[0]);
-            // No suggestion matched (e.g. a numeric jump like ":5" or ":$") —
-            // run the raw input so the dispatcher can still handle it.
-            else submit(input);
+            // Exact command → run input as-is (keeps args); else the highlighted
+            // suggestion; else the raw input (numeric jumps like :5 / :$).
+            submit(resolveEnter(commands, input, active));
           }
         }}
       >

--- a/desktop/frontend/src/commands.test.ts
+++ b/desktop/frontend/src/commands.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import {
+  COMMANDS,
+  parseCommand,
+  filterCommands,
+  resolveEnter,
+  type CommandDef,
+} from "./commands";
+
+describe("parseCommand", () => {
+  it("lowercases the command and keeps the raw argument", () => {
+    expect(parseCommand("s from:me has:attachment")).toEqual({
+      cmd: "s",
+      arg: "from:me has:attachment",
+    });
+    expect(parseCommand("ARCHIVE")).toEqual({ cmd: "archive", arg: "" });
+  });
+  it("collapses surrounding / repeated whitespace", () => {
+    expect(parseCommand("   plan    rules  ")).toEqual({ cmd: "plan", arg: "rules" });
+  });
+});
+
+describe("filterCommands", () => {
+  const has = (list: CommandDef[], name: string) =>
+    list.some((c) => c.names.includes(name));
+
+  it("returns everything for empty input", () => {
+    expect(filterCommands(COMMANDS, "")).toBe(COMMANDS);
+  });
+  it("matches by name OR alias prefix on the first word only", () => {
+    const m = filterCommands(COMMANDS, "arch");
+    expect(has(m, "archive")).toBe(true);
+    expect(has(m, "archived")).toBe(true); // alias arch-search also starts with "arch"
+    expect(has(m, "search")).toBe(false);
+  });
+  it("ignores the argument when filtering", () => {
+    const m = filterCommands(COMMANDS, "search from:me");
+    expect(m.length).toBe(1);
+    expect(m[0].names[0]).toBe("search");
+  });
+});
+
+describe("resolveEnter", () => {
+  it("returns the input verbatim when the first word is an exact command/alias (keeps args)", () => {
+    expect(resolveEnter(COMMANDS, "search from:me", 0)).toBe("search from:me");
+    expect(resolveEnter(COMMANDS, "u", 0)).toBe("u"); // alias of unread
+    expect(resolveEnter(COMMANDS, "sq", 0)).toBe("sq"); // alias of savequery
+  });
+  it("returns the highlighted suggestion's canonical name for a prefix", () => {
+    // "arch" is not an exact command; matches[0] is the earliest in COMMANDS.
+    expect(resolveEnter(COMMANDS, "arch", 0)).toBe("archive");
+  });
+  it("returns the raw input when nothing matches (numeric jumps)", () => {
+    expect(resolveEnter(COMMANDS, "5", 0)).toBe("5");
+    expect(resolveEnter(COMMANDS, "$", 0)).toBe("$"); // '$' is an exact alias of bottom → verbatim
+  });
+});
+
+describe("COMMANDS integrity", () => {
+  it("has unique canonical names and no duplicate alias across commands", () => {
+    const seen = new Map<string, string>();
+    for (const c of COMMANDS) {
+      for (const n of c.names) {
+        expect(seen.has(n), `duplicate command token "${n}" (also in ${seen.get(n)})`).toBe(false);
+        seen.set(n, c.names[0]);
+      }
+    }
+  });
+});

--- a/desktop/frontend/src/commands.ts
+++ b/desktop/frontend/src/commands.ts
@@ -1,0 +1,124 @@
+// Command-palette data + pure resolution logic, extracted from App.tsx and
+// CommandBar.tsx so aliasing / arg-parsing / Enter-resolution can be unit-tested
+// without React. The big executeCommand switch in App.tsx stays as the handler
+// adapter; only the pure pieces live here.
+
+export interface CommandDef {
+  names: string[]; // first is canonical, rest are aliases
+  desc: string;
+  arg?: string; // placeholder hint when the command takes an argument
+}
+
+function firstWord(input: string): string {
+  return input.trim().split(/\s+/)[0]?.toLowerCase() ?? "";
+}
+
+// parseCommand splits ":cmd arg rest" into a lowercased command and the raw
+// remainder (used by executeCommand's dispatcher).
+export function parseCommand(input: string): { cmd: string; arg: string } {
+  const parts = input.trim().split(/\s+/);
+  return { cmd: (parts[0] || "").toLowerCase(), arg: parts.slice(1).join(" ") };
+}
+
+// filterCommands is the palette autocomplete: every command with a name that
+// starts with the typed first word (all of them when nothing is typed).
+export function filterCommands(commands: CommandDef[], input: string): CommandDef[] {
+  const word = firstWord(input);
+  if (!word) return commands;
+  return commands.filter((c) => c.names.some((n) => n.toLowerCase().startsWith(word)));
+}
+
+// resolveEnter returns the string the CommandBar should run on Enter: the typed
+// input verbatim when it exactly names a command (so arguments are preserved),
+// otherwise the highlighted suggestion's canonical name, otherwise the raw input
+// (so numeric jumps like ":5" / ":$" still reach the dispatcher).
+export function resolveEnter(
+  commands: CommandDef[],
+  input: string,
+  activeIndex: number,
+): string {
+  const word = firstWord(input);
+  const exact = commands.find((c) => c.names.some((n) => n.toLowerCase() === word));
+  if (exact) return input;
+  const matches = filterCommands(commands, input);
+  if (matches[activeIndex]) return matches[activeIndex].names[0];
+  return input;
+}
+
+// Command palette entries (`:` command mode), mirroring the TUI's command set.
+export const COMMANDS: CommandDef[] = [
+  { names: ["search", "s"], desc: "Gmail search", arg: "<query>" },
+  { names: ["unread", "u"], desc: "Show unread only" },
+  { names: ["advanced", "adv"], desc: "Advanced search builder" },
+  { names: ["local"], desc: "Toggle local filter / Gmail search" },
+  { names: ["stats", "usage"], desc: "AI prompt usage stats" },
+  { names: ["config", "cfg"], desc: "Show configuration" },
+  { names: ["cache"], desc: "Clear AI caches" },
+  { names: ["archive", "a"], desc: "Archive message" },
+  { names: ["trash", "d"], desc: "Trash message" },
+  { names: ["undo"], desc: "Undo last action" },
+  { names: ["read"], desc: "Mark read" },
+  { names: ["markunread"], desc: "Mark unread" },
+  { names: ["toggle-read", "t"], desc: "Toggle read / unread" },
+  { names: ["labels", "l"], desc: "Manage labels" },
+  { names: ["compose", "c", "new"], desc: "New message" },
+  { names: ["reply", "r"], desc: "Reply" },
+  { names: ["replyall", "reply-all", "ra"], desc: "Reply all" },
+  { names: ["forward", "f"], desc: "Forward" },
+  { names: ["refresh"], desc: "Refresh inbox" },
+  { names: ["drafts", "dr"], desc: "Drafts" },
+  { names: ["links", "link"], desc: "Links in message" },
+  { names: ["save"], desc: "Save to file" },
+  { names: ["save-raw", "saveraw"], desc: "Save raw .eml" },
+  { names: ["rsvp"], desc: "Open RSVP picker for invite" },
+  { names: ["accept"], desc: "RSVP: accept invite" },
+  { names: ["tentative", "maybe"], desc: "RSVP: tentative" },
+  { names: ["decline"], desc: "RSVP: decline invite" },
+  { names: ["autorefresh", "arr"], desc: "Toggle inbox auto-refresh" },
+  { names: ["summarize", "sum", "summary"], desc: "AI summary" },
+  { names: ["prompt", "pr", "p"], desc: "Apply a prompt" },
+  { names: ["prompts", "prompt-new"], desc: "Manage prompts" },
+  { names: ["suggest"], desc: "Suggest labels (AI)" },
+  { names: ["obsidian", "obs"], desc: "Send to Obsidian" },
+  { names: ["slack", "sl"], desc: "Forward to Slack" },
+  { names: ["gmail", "web", "open-web", "o"], desc: "Open in Gmail" },
+  { names: ["threads", "thr"], desc: "Toggle conversation view" },
+  { names: ["expand-all", "expand", "flatten", "flat"], desc: "Expand all in thread" },
+  { names: ["collapse-all", "collapse"], desc: "Collapse all in thread" },
+  { names: ["thread-summary", "th-sum"], desc: "Summarize thread (AI)" },
+  { names: ["inbox", "i"], desc: "Back to inbox" },
+  { names: ["archived", "b", "arch-search"], desc: "Archived messages" },
+  { names: ["markdown", "md"], desc: "Toggle HTML / text" },
+  { names: ["images", "remote", "img"], desc: "Load / block remote images" },
+  { names: ["images-always", "always-images", "imgall"], desc: "Always load remote images (on/off)" },
+  { names: ["load", "more", "next"], desc: "Load more messages" },
+  { names: ["attachments", "attach"], desc: "Focus attachments" },
+  { names: ["accounts", "acc"], desc: "Switch account" },
+  { names: ["label", "lbl"], desc: "Add label by name", arg: "<name>" },
+  { names: ["select", "sel"], desc: "Bulk-select rows", arg: "all|none|<n|a-b>" },
+  { names: ["goto", "g"], desc: "Go to row", arg: "[n]" },
+  { names: ["bottom", "end", "$"], desc: "Go to last row" },
+  { names: ["queries"], desc: "Saved searches" },
+  { names: ["savequery", "save-query", "sq"], desc: "Save current search" },
+  { names: ["plan", "actionplan", "action-plan", "ap"], desc: "AI inbox action plan", arg: "[rules|prompt]" },
+  { names: ["rules", "ru"], desc: "Deterministic rules manager", arg: "[run|plan]" },
+  { names: ["rp"], desc: "Run deterministic rules (:rules plan)" },
+  { names: ["move", "mv"], desc: "Move to folder", arg: "[label]" },
+  { names: ["draft", "replyai"], desc: "Draft reply (AI)" },
+  { names: ["find"], desc: "Find in message", arg: "<text>" },
+  { names: ["from"], desc: "Search from this sender" },
+  { names: ["to"], desc: "Search to this recipient" },
+  { names: ["subject"], desc: "Search this subject" },
+  { names: ["headers", "toggle-headers"], desc: "Toggle headers" },
+  { names: ["toolbar"], desc: "Show/hide reader toolbar" },
+  { names: ["zoom-in", "zi"], desc: "Bigger UI text (Cmd/Ctrl +)" },
+  { names: ["zoom-out", "zo"], desc: "Smaller UI text (Cmd/Ctrl -)" },
+  { names: ["zoom-reset"], desc: "Reset UI zoom (Cmd/Ctrl 0)" },
+  { names: ["zoom"], desc: "Set UI zoom", arg: "<0.6-2.4>" },
+  { names: ["touch-up", "touchup"], desc: "Reformat message with AI" },
+  { names: ["theme", "th"], desc: "Change theme", arg: "[name]" },
+  { names: ["regenerate", "regen"], desc: "Regenerate the open AI panel (summary/prompt)" },
+  { names: ["dismiss", "close-ai"], desc: "Close the open AI panel" },
+  { names: ["quit", "q", "exit"], desc: "Quit GizTUI" },
+  { names: ["help", "h"], desc: "Keyboard shortcuts" },
+];

--- a/desktop/frontend/src/compose.test.ts
+++ b/desktop/frontend/src/compose.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { replyInit, replyAllInit, forwardInit } from "./compose";
+import type { MessageDetail } from "./api";
+
+// Minimal MessageDetail factory — only the fields the builders read matter.
+const msg = (o: Partial<MessageDetail>): MessageDetail =>
+  ({
+    id: "m1",
+    from: "Ada <ada@x.com>",
+    to: "me@x.com",
+    cc: "",
+    subject: "Hello",
+    date: "2026-07-20T10:00:00Z",
+    plainText: "body text",
+    html: "",
+    unread: false,
+    ...o,
+  }) as MessageDetail;
+
+describe("replyInit", () => {
+  it("replies to the sender, threaded on the original", () => {
+    expect(replyInit(msg({ id: "abc", from: "Ada <ada@x.com>" }))).toEqual({
+      mode: "reply",
+      originalId: "abc",
+      to: "Ada <ada@x.com>",
+    });
+  });
+});
+
+describe("replyAllInit", () => {
+  it("adds the original To/Cc as Cc, de-duplicated", () => {
+    const r = replyAllInit(
+      msg({ from: "ada@x.com", to: "bob@x.com, carol@x.com", cc: "carol@x.com, dave@x.com" }),
+    );
+    expect(r.mode).toBe("reply");
+    expect(r.to).toBe("ada@x.com");
+    const cc = (r.cc || "").split(", ").sort();
+    expect(cc).toEqual(["bob@x.com", "carol@x.com", "dave@x.com"]);
+  });
+  it("never re-adds the sender to Cc", () => {
+    const r = replyAllInit(msg({ from: "ada@x.com", to: "ada@x.com, bob@x.com", cc: "" }));
+    expect(r.cc).toBe("bob@x.com");
+  });
+  it("yields an empty Cc when there are no other recipients", () => {
+    const r = replyAllInit(msg({ from: "ada@x.com", to: "", cc: "" }));
+    expect(r.cc).toBe("");
+  });
+});
+
+describe("forwardInit", () => {
+  it("prefixes Fwd: once and quotes the original", () => {
+    const r = forwardInit(msg({ subject: "Report", from: "Ada <ada@x.com>", plainText: "hi" }));
+    expect(r.mode).toBe("new");
+    expect(r.subject).toBe("Fwd: Report");
+    expect(r.body).toContain("---------- Forwarded message ----------");
+    expect(r.body).toContain("From: Ada <ada@x.com>");
+    expect(r.body).toContain("hi");
+  });
+  it("does not double-prefix an already-forwarded subject", () => {
+    expect(forwardInit(msg({ subject: "Fwd: Report" })).subject).toBe("Fwd: Report");
+  });
+});

--- a/desktop/frontend/src/compose.ts
+++ b/desktop/frontend/src/compose.ts
@@ -1,0 +1,34 @@
+// Pure builders that turn an open message into the initial state for the
+// composer (reply / reply-all / forward). Extracted from App.tsx so the
+// recipient/subject/body derivation can be unit-tested without React.
+import type { MessageDetail } from "./api";
+import type { ComposeInit } from "./Compose";
+
+export function replyInit(d: MessageDetail): ComposeInit {
+  return { mode: "reply", originalId: d.id, to: d.from };
+}
+
+// Reply-all: reply to the sender, adding the original To/Cc recipients as Cc
+// (de-duplicated, and never re-adding the sender).
+export function replyAllInit(d: MessageDetail): ComposeInit {
+  const extra = [d.to, d.cc]
+    .filter(Boolean)
+    .join(", ")
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s && !d.from.includes(s));
+  return {
+    mode: "reply",
+    originalId: d.id,
+    to: d.from,
+    cc: [...new Set(extra)].join(", "),
+  };
+}
+
+export function forwardInit(d: MessageDetail): ComposeInit {
+  return {
+    mode: "new",
+    subject: d.subject.startsWith("Fwd:") ? d.subject : `Fwd: ${d.subject}`,
+    body: `\n\n---------- Forwarded message ----------\nFrom: ${d.from}\nDate: ${d.date}\nSubject: ${d.subject}\nTo: ${d.to}\n\n${d.plainText}`,
+  };
+}

--- a/desktop/frontend/src/format.test.ts
+++ b/desktop/frontend/src/format.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  displayName,
+  matchesCombo,
+  emailAddr,
+  labelForAction,
+  formatICSDate,
+  mixHex,
+  cleanSubject,
+  countMatches,
+  formatDate,
+  formatFull,
+  formatSize,
+} from "./format";
+
+describe("displayName", () => {
+  it("prefers the quoted/display part before <addr>", () => {
+    expect(displayName('"Ada Lovelace" <ada@x.com>')).toBe("Ada Lovelace");
+    expect(displayName("Ada Lovelace <ada@x.com>")).toBe("Ada Lovelace");
+  });
+  it("falls back to the local-part when there is no display name", () => {
+    expect(displayName("ada@x.com")).toBe("ada");
+  });
+  it("returns the input when there is no @ and no <", () => {
+    expect(displayName("system")).toBe("system");
+  });
+});
+
+describe("emailAddr", () => {
+  it("extracts the address inside angle brackets", () => {
+    expect(emailAddr('"Ada" <ada@x.com>')).toBe("ada@x.com");
+  });
+  it("returns the input when there are no brackets", () => {
+    expect(emailAddr("ada@x.com")).toBe("ada@x.com");
+  });
+});
+
+describe("cleanSubject", () => {
+  it("strips Re:/Fwd:/Fw: prefixes (repeated, case-insensitive)", () => {
+    expect(cleanSubject("Re: hello")).toBe("hello");
+    expect(cleanSubject("FWD: Re:  hello")).toBe("hello");
+    expect(cleanSubject("fw: hi")).toBe("hi");
+  });
+  it("leaves a clean subject untouched", () => {
+    expect(cleanSubject("Meeting notes")).toBe("Meeting notes");
+  });
+  it("keeps the original if stripping would empty it", () => {
+    expect(cleanSubject("Re:")).toBe("Re:");
+  });
+});
+
+describe("countMatches", () => {
+  it("counts case-insensitive, non-overlapping occurrences", () => {
+    expect(countMatches("aXaXa", "x")).toBe(2);
+    expect(countMatches("Hello hello HELLO", "hello")).toBe(3);
+  });
+  it("returns 0 for an empty query or no match", () => {
+    expect(countMatches("abc", "")).toBe(0);
+    expect(countMatches("abc", "z")).toBe(0);
+  });
+});
+
+describe("formatSize", () => {
+  it("formats bytes with the right unit and precision", () => {
+    expect(formatSize(0)).toBe("");
+    expect(formatSize(512)).toBe("512 B");
+    expect(formatSize(1024)).toBe("1.0 KB");
+    expect(formatSize(1536)).toBe("1.5 KB");
+    expect(formatSize(1024 * 1024)).toBe("1.0 MB");
+    expect(formatSize(5 * 1024 * 1024 * 1024)).toBe("5.0 GB");
+  });
+});
+
+describe("mixHex", () => {
+  it("returns the endpoints at t=0 and t=1", () => {
+    expect(mixHex("#000000", "#ffffff", 0)).toBe("#000000");
+    expect(mixHex("#000000", "#ffffff", 1)).toBe("#ffffff");
+  });
+  it("blends at the midpoint and expands #rgb shorthand", () => {
+    expect(mixHex("#000", "#fff", 0.5)).toBe("#808080");
+  });
+  it("falls back to the first color when either is unparseable", () => {
+    expect(mixHex("nope", "#fff", 0.5)).toBe("nope");
+    expect(mixHex("#123", "zzz", 0.5)).toBe("#123"); // zzz is not hex
+    expect(mixHex("#12", "#fff", 0.5)).toBe("#12"); // wrong length
+  });
+});
+
+describe("labelForAction", () => {
+  it("maps known actions to their present participle", () => {
+    expect(labelForAction("archive")).toBe("Archiving");
+    expect(labelForAction("trash")).toBe("Trashing");
+    expect(labelForAction("read")).toBe("Marking read");
+    expect(labelForAction("unread")).toBe("Marking unread");
+  });
+  it("falls back for unknown actions", () => {
+    expect(labelForAction("whatever")).toBe("Working on");
+  });
+});
+
+describe("matchesCombo", () => {
+  const ev = (o: Partial<KeyboardEvent>): KeyboardEvent =>
+    ({ ctrlKey: false, metaKey: false, shiftKey: false, altKey: false, key: "", ...o }) as KeyboardEvent;
+
+  it("treats ctrl and cmd as interchangeable", () => {
+    expect(matchesCombo(ev({ ctrlKey: true, key: "f" }), "ctrl+f")).toBe(true);
+    expect(matchesCombo(ev({ metaKey: true, key: "f" }), "ctrl+f")).toBe(true);
+  });
+  it("requires the modifier — a bare key never matches", () => {
+    expect(matchesCombo(ev({ key: "f" }), "ctrl+f")).toBe(false);
+    expect(matchesCombo(ev({ key: "a" }), "a")).toBe(false);
+  });
+  it("respects shift and alt requirements exactly", () => {
+    expect(matchesCombo(ev({ ctrlKey: true, shiftKey: true, key: "p" }), "ctrl+shift+p")).toBe(true);
+    expect(matchesCombo(ev({ ctrlKey: true, key: "p" }), "ctrl+shift+p")).toBe(false);
+    expect(matchesCombo(ev({ altKey: true, key: "x" }), "alt+x")).toBe(true);
+  });
+});
+
+describe("date formatters (deterministic pieces only)", () => {
+  it("formatDate returns '' for an invalid date and 'now' for the present", () => {
+    expect(formatDate("not-a-date")).toBe("");
+    expect(formatDate(new Date().toISOString())).toBe("now");
+  });
+  it("formatDate buckets minutes/hours/days", () => {
+    const ago = (ms: number) => new Date(Date.now() - ms).toISOString();
+    expect(formatDate(ago(5 * 60_000))).toBe("5m");
+    expect(formatDate(ago(3 * 3_600_000))).toBe("3h");
+    expect(formatDate(ago(2 * 86_400_000))).toBe("2d");
+  });
+  it("formatFull returns '' for an invalid date, non-empty otherwise", () => {
+    expect(formatFull("not-a-date")).toBe("");
+    expect(formatFull("2026-07-20T10:00:00Z").length).toBeGreaterThan(0);
+  });
+  it("formatICSDate returns the raw input when it can't parse", () => {
+    expect(formatICSDate("garbage")).toBe("garbage");
+    // a parseable value produces a non-empty, different string
+    const out = formatICSDate("20260720T150000");
+    expect(out).not.toBe("20260720T150000");
+    expect(out.length).toBeGreaterThan(0);
+  });
+});

--- a/desktop/frontend/src/format.ts
+++ b/desktop/frontend/src/format.ts
@@ -1,0 +1,145 @@
+// Pure formatting / parsing helpers shared across the app. Extracted from
+// App.tsx so they can be unit-tested in isolation (no React, no state).
+
+export function displayName(from: string): string {
+  const m = from.match(/^\s*"?([^"<]+?)"?\s*</);
+  if (m) return m[1].trim();
+  return from.split("@")[0] || from;
+}
+
+// matchesCombo reports whether a keyboard event matches a TUI-style modifier
+// combo like "ctrl+f" or "ctrl+shift+p". Ctrl and Cmd are treated as
+// interchangeable so a config's "ctrl+f" also fires on macOS's Cmd+F. Only
+// combos that include a modifier are matched — a bare key returns false so it
+// never hijacks normal typing/actions.
+export function matchesCombo(e: KeyboardEvent, combo: string): boolean {
+  const parts = combo.toLowerCase().split("+");
+  const key = parts[parts.length - 1];
+  const wantCtrlOrMeta = parts.includes("ctrl") || parts.includes("cmd") || parts.includes("meta");
+  const wantShift = parts.includes("shift");
+  const wantAlt = parts.includes("alt") || parts.includes("option");
+  if (!wantCtrlOrMeta && !wantAlt) return false; // require a modifier
+  if (wantCtrlOrMeta !== (e.ctrlKey || e.metaKey)) return false;
+  if (wantAlt !== e.altKey) return false;
+  if (wantShift !== e.shiftKey) return false;
+  return e.key.toLowerCase() === key;
+}
+
+export function emailAddr(from: string): string {
+  const m = from.match(/<([^>]+)>/);
+  return m ? m[1] : from;
+}
+
+// labelForAction is the present-participle verb shown while a bulk action runs.
+export function labelForAction(action: string): string {
+  switch (action) {
+    case "archive":
+      return "Archiving";
+    case "trash":
+      return "Trashing";
+    case "read":
+      return "Marking read";
+    case "unread":
+      return "Marking unread";
+    default:
+      return "Working on";
+  }
+}
+
+// formatICSDate turns an iCalendar date-time (optionally with a ;TZID= prefix,
+// e.g. "20260720T150000" or ";TZID=Europe/Madrid:20260720T150000") into a
+// human-readable local string.
+export function formatICSDate(raw: string): string {
+  const v = raw.includes(":") ? raw.slice(raw.lastIndexOf(":") + 1) : raw;
+  const m = v.match(/^(\d{4})(\d{2})(\d{2})(?:T(\d{2})(\d{2})(\d{2})?Z?)?/);
+  if (!m) return raw;
+  const [, y, mo, d, hh = "00", mm = "00"] = m;
+  const dt = new Date(
+    Number(y),
+    Number(mo) - 1,
+    Number(d),
+    Number(hh),
+    Number(mm),
+  );
+  if (Number.isNaN(dt.getTime())) return raw;
+  return dt.toLocaleString([], {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+// mixHex blends hex color `a` toward `b` by t∈[0,1]. Falls back to `a` when
+// either isn't a parseable #rgb / #rrggbb string, so theme mapping never breaks.
+export function mixHex(a: string, b: string, t: number): string {
+  const parse = (h: string): [number, number, number] | null => {
+    let s = h.trim().replace(/^#/, "");
+    if (s.length === 3) s = s.replace(/(.)/g, "$1$1");
+    if (s.length !== 6 || /[^0-9a-fA-F]/.test(s)) return null;
+    return [
+      parseInt(s.slice(0, 2), 16),
+      parseInt(s.slice(2, 4), 16),
+      parseInt(s.slice(4, 6), 16),
+    ];
+  };
+  const ca = parse(a);
+  const cb = parse(b);
+  if (!ca || !cb) return a;
+  const mix = (x: number, y: number) =>
+    Math.round(x + (y - x) * t)
+      .toString(16)
+      .padStart(2, "0");
+  return `#${mix(ca[0], cb[0])}${mix(ca[1], cb[1])}${mix(ca[2], cb[2])}`;
+}
+
+// cleanSubject strips Re:/Fwd: prefixes so a subject search matches the thread.
+export function cleanSubject(subject: string): string {
+  return subject.replace(/^(\s*(re|fwd|fw)\s*:\s*)+/i, "").trim() || subject;
+}
+
+// countMatches returns how many times query occurs in text (case-insensitive).
+export function countMatches(text: string, query: string): number {
+  if (!query) return 0;
+  const q = query.toLowerCase();
+  const t = text.toLowerCase();
+  let n = 0;
+  let i = t.indexOf(q);
+  while (i !== -1) {
+    n++;
+    i = t.indexOf(q, i + q.length);
+  }
+  return n;
+}
+
+export function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const mins = Math.floor((Date.now() - d.getTime()) / 60000);
+  if (mins < 1) return "now";
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d`;
+  return d.toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
+export function formatFull(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleString();
+}
+
+export function formatSize(bytes: number): string {
+  if (bytes <= 0) return "";
+  const units = ["B", "KB", "MB", "GB"];
+  let n = bytes;
+  let u = 0;
+  while (n >= 1024 && u < units.length - 1) {
+    n /= 1024;
+    u++;
+  }
+  return `${n.toFixed(u === 0 ? 0 : 1)} ${units[u]}`;
+}

--- a/desktop/frontend/vitest.config.ts
+++ b/desktop/frontend/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+// Unit-test config, separate from vite.config.ts (the build). Pure logic lives
+// in small modules extracted from App.tsx; jsdom gives us DOM types (e.g.
+// KeyboardEvent) without a browser. Integration flows are covered separately by
+// Playwright against the api.ts mock.
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/docs/DESKTOP_REFACTOR_PLAN.md
+++ b/docs/DESKTOP_REFACTOR_PLAN.md
@@ -146,7 +146,7 @@ Extract **as behavior-preserving moves**, safest → riskiest, Playwright in fro
 ## 7. Progress tracker
 
 - [x] **F0** Harness — vitest + jsdom, `test` script (Playwright suite deferred to F3 start)
-- [~] **F1** Pure helpers + unit tests — `format.ts` (11 fns) extracted + 23 tests ✅; compose builders pending
+- [x] **F1** Pure helpers + unit tests — `format.ts` (11 fns, 23 tests) + `compose.ts` (reply/replyAll/forward, 6 tests) ✅
 - [ ] **F2** Command layer + unit tests
 - [ ] **F3.1** useZoom / useTheme
 - [ ] **F3.2** useThreading / useAttachments / useRsvp

--- a/docs/DESKTOP_REFACTOR_PLAN.md
+++ b/docs/DESKTOP_REFACTOR_PLAN.md
@@ -147,7 +147,7 @@ Extract **as behavior-preserving moves**, safest → riskiest, Playwright in fro
 
 - [x] **F0** Harness — vitest + jsdom, `test` script (Playwright suite deferred to F3 start)
 - [x] **F1** Pure helpers + unit tests — `format.ts` (11 fns, 23 tests) + `compose.ts` (reply/replyAll/forward, 6 tests) ✅
-- [ ] **F2** Command layer + unit tests
+- [x] **F2** Command layer — `commands.ts` (COMMANDS + pure `parseCommand`/`filterCommands`/`resolveEnter`), CommandBar/App rewired, 9 unit tests + integrity check ✅. Scope kept safe: the big `executeCommand` switch stays as the handler adapter; **data-driven dispatch (actions object) is deferred** — low marginal value, higher risk.
 - [ ] **F3.1** useZoom / useTheme
 - [ ] **F3.2** useThreading / useAttachments / useRsvp
 - [ ] **F3.3** useMessages

--- a/docs/DESKTOP_REFACTOR_PLAN.md
+++ b/docs/DESKTOP_REFACTOR_PLAN.md
@@ -1,0 +1,165 @@
+# 🧭 Desktop `App.tsx` Decomposition & Test-Coverage Plan
+
+> **Why this file exists.** `App.tsx` grew into a 5.6k-line god component during
+> the desktop build-out, with **zero** frontend test coverage. Breaking it up is
+> risky *because* that's where the subtle, coupled bugs live. This plan is the
+> **durable source of truth** for that work — written to the repo (not to any
+> assistant's ephemeral context) so a fresh session, or a human, can pick it up
+> mid-flight. Update the **Progress tracker** as phases land.
+
+**Status:** DRAFT — pending sign-off on approach. Nothing refactored yet.
+**Owner:** _tbd_ · **Last updated:** 2026-07-25
+
+---
+
+## 1. Current state (measured, not guessed)
+
+`desktop/frontend/src/App.tsx`:
+
+| Metric | Count |
+| --- | --- |
+| Lines | ~5,618 |
+| `useState` | 121 |
+| `useRef` | 28 |
+| `useCallback` | 81 |
+| `useEffect` | 14 |
+| Inline `backend.*` API calls | 88 |
+| Modals/pickers rendered in one JSX tree | ~21 |
+| Setters touching the Prompt/AI subsystem | **68** (the biggest single tangle) |
+
+Frontend test coverage: **0%** — no vitest/jest, no `test` script. Only manual +
+ad-hoc Playwright-against-the-mock has ever exercised it.
+
+Go coverage for reference: `internal/services` 32%, `pkg/desktop` 24%,
+`internal/tui` 9.7% (measured 2026-07-25).
+
+## 2. Goals & non-goals
+
+**Goals, in priority order:**
+1. **Regression safety.** This app keeps surfacing coupling bugs; the #1 job is a
+   net that catches them, then structure that makes them less likely.
+2. **Testability.** Pull logic out of the render component so it can be unit-tested.
+3. **Maintainability.** Smaller, single-responsibility modules.
+
+**Non-goals (explicitly out of scope for now):**
+- Rewriting behavior or "improving" UX while refactoring. **Zero behavior change.**
+- A state-management library (Redux/Zustand/etc.). Not yet — decide later.
+- Touching the TUI Go monoliths (`messages.go`, `app.go`). Separate effort.
+- Big-bang. Never.
+
+## 3. Landmines — the coupling that caused our bugs (READ THIS FIRST)
+
+Do **not** extract anything below without preserving these exact contracts:
+
+- **`openIdRef`** is read inside streaming callbacks so a run started on message A
+  never paints into the panel after you've navigated to B. Any hook that streams
+  must keep reading the *live* ref, not a captured value.
+- **`summaryForId` / `promptForId` / `runningLabelRef`** gate which message a run
+  belongs to (title/body must not bleed across messages). 
+- **`loadMessage` is `useCallback([])` on purpose** for identity stability; it is
+  called from many places and effects. Changing its deps has ripple effects.
+- **Mirror refs** (`summaryRef`, `promptResultRef`, `promptLabelRef`, …) exist to
+  dodge stale closures in window-level handlers. Extractions must keep the
+  ref-freshness pattern, not "clean it up" into plain deps.
+- **`chordAction` is first-binding-wins** (mirrors the TUI's first-match), e.g.
+  a remapped `Y` resolves to load-more, shadowing regenerate. Order matters.
+- **`anyModal` Escape chain** closes the *topmost* modal in a specific order;
+  WKWebView won't focus bare divs, so keys come from **window listeners**.
+- **The order of state resets in `loadMessage`** is load-bearing (we fixed the
+  "blank prompt title on return" bug by *not* clobbering live streaming state).
+
+If a change can't preserve these, it doesn't ship.
+
+## 4. Strategy
+
+**Options considered:**
+- **A. Just add tests, no structural change.** Lowest risk, but leaves the
+  god-file; coverage of a 5.6k component is shallow.
+- **B. Characterization tests first, then refactor under their protection.** ✅
+  Correct for a risky, coupled file with no net.
+- **C. Big-bang split into hooks/components.** Fast on paper, high blast radius,
+  exactly what caused the bugs. Rejected.
+- **D. Strangler / incremental extraction by risk**, each step shippable. ✅
+
+**Chosen: B + D.** Build the net first, then peel off cohesive pieces
+lowest-risk → highest-risk, each an independent PR that must stay behavior-identical.
+
+## 5. Testing strategy (two layers — be honest about what each covers)
+
+| Layer | Tooling | Covers | Does NOT cover |
+| --- | --- | --- | --- |
+| **Unit** | vitest + jsdom | Pure & near-pure logic: `format.ts`, command parse/match, compose builders, any cache logic extracted as pure functions | Coupled runtime behavior (WKWebView, window listeners, focus, streaming order) — jsdom can't reproduce it |
+| **Integration** | Playwright + the api.ts **mock** | The coupled flows where bugs live: open→summarize→apply prompt→switch→return→dismiss; search scoping; delete/prune; bulk; picker keyboard nav | Fine-grained internal logic (do that in unit) |
+
+**Key insight:** the integration layer is the real protection for this refactor —
+it's where every bug this session actually lived. We've been running these flows
+by hand; **formalizing them into a committed, repeatable suite is the highest-value
+first step.** Do not over-invest in jsdom component tests of `App` itself.
+
+## 6. Phased plan
+
+Each phase = one small PR. **Gate for every PR:** `tsc --noEmit` clean, `npm run
+build` clean, `go build ./pkg/desktop/ && (cd desktop && go build ./...)` clean,
+unit tests green, **Playwright smoke green**, and a manual read of the diff
+confirming zero behavior change.
+
+### F0 — Harness (do this first; it makes everything else safe)
+- Add **vitest + jsdom** (devDeps), a `test` script, minimal config.
+- Formalize 3–5 **Playwright** smokes we already run by hand into a committed
+  suite (open message, summarize, apply-prompt-then-switch-then-return, search
+  scope, delete). A tiny runner + the pre-installed Chromium.
+- **DoD:** `npm test` runs unit; a documented command runs the Playwright suite;
+  both green in CI-equivalent local run.
+
+### F1 — Pure helpers (near-zero risk)
+- `format.ts`: `displayName`, `emailAddr`, `cleanSubject`, `countMatches`,
+  `formatDate`, `formatFull`, `formatSize`, `matchesCombo`, `formatICSDate`,
+  `mixHex`, `labelForAction` (already scoped once; ~11 fns).
+- Compose builders (`replyInit`, `replyAllInit`, `forwardInit`) + quick-search
+  query building, if verified pure.
+- **Unit tests for each.** −~200–250 lines from `App.tsx`.
+
+### F2 — Command layer (medium risk, high coverage payoff)
+- `commands.ts`: the `COMMANDS` table + a dispatcher parameterized by an
+  **actions object** (so it's testable without React). `executeCommand` becomes
+  a thin adapter that passes real handlers in.
+- **Unit-test** command resolution / aliasing / arg parsing.
+
+### F3 — Subsystem hooks (highest risk — separate, careful sessions)
+Extract **as behavior-preserving moves**, safest → riskiest, Playwright in front:
+1. `useZoom`, `useTheme` (small, isolated).
+2. `useThreading`, `useAttachments`, `useRsvp`.
+3. `useMessages` (list/load/pagination/pendingNew/prune) — touches `openIdRef`.
+4. **`useAiPanels`** LAST (summarize/prompt/touchUp/cache/regenerate/dismiss +
+   the ForId/running/mirror refs) — the 68-setter tangle. This is where the bugs
+   were; treat with maximum care and full Playwright coverage.
+
+### F4 — JSX component splits (mechanical, verbose)
+- `<MessageList>`, `<Reader>` (+ toolbar), and lift the ~21 modals into their own
+  files where they aren't already. Prop-drilling or a small context; decide then.
+
+## 7. Progress tracker
+
+- [ ] **F0** Harness (vitest + Playwright suite)
+- [ ] **F1** Pure helpers + unit tests
+- [ ] **F2** Command layer + unit tests
+- [ ] **F3.1** useZoom / useTheme
+- [ ] **F3.2** useThreading / useAttachments / useRsvp
+- [ ] **F3.3** useMessages
+- [ ] **F3.4** useAiPanels  ⚠️ highest risk
+- [ ] **F4** JSX component splits
+
+## 8. Safety rules (non-negotiable)
+
+1. One cohesive change per PR; small diffs.
+2. The full gate (§6) green before merge. No exceptions for "it's obviously fine."
+3. **Zero behavior change** in a refactor PR. Behavior changes are separate PRs.
+4. Stop before F3 unless F0 is done and Playwright is protecting the flow.
+5. If a step can't preserve a §3 landmine contract, abandon that step and rethink.
+
+## 9. Open decisions (needed before executing)
+
+- [ ] Approve **vitest + jsdom** as the unit harness.
+- [ ] Confirm order: **F0 → F1 → F2 this batch; F3 (hooks) in dedicated sessions.**
+- [ ] Where do Playwright specs live (`desktop/frontend/e2e/`?) and do we wire them
+  into CI or keep them local-run for now?

--- a/docs/DESKTOP_REFACTOR_PLAN.md
+++ b/docs/DESKTOP_REFACTOR_PLAN.md
@@ -7,8 +7,13 @@
 > assistant's ephemeral context) so a fresh session, or a human, can pick it up
 > mid-flight. Update the **Progress tracker** as phases land.
 
-**Status:** DRAFT — pending sign-off on approach. Nothing refactored yet.
+**Status:** APPROVED — executing F0 → F1 → F2 this batch (F3 hooks deferred).
 **Owner:** _tbd_ · **Last updated:** 2026-07-25
+
+> **Sequencing note (refinement, approved):** Playwright integration tests protect
+> the *coupled* refactors (F3). F1/F2 are pure/near-pure and are protected by unit
+> tests, so this batch only stands up the **vitest** harness now; the Playwright
+> suite is built at the **start of F3** (when it actually guards a coupled change).
 
 ---
 
@@ -140,8 +145,8 @@ Extract **as behavior-preserving moves**, safest → riskiest, Playwright in fro
 
 ## 7. Progress tracker
 
-- [ ] **F0** Harness (vitest + Playwright suite)
-- [ ] **F1** Pure helpers + unit tests
+- [x] **F0** Harness — vitest + jsdom, `test` script (Playwright suite deferred to F3 start)
+- [~] **F1** Pure helpers + unit tests — `format.ts` (11 fns) extracted + 23 tests ✅; compose builders pending
 - [ ] **F2** Command layer + unit tests
 - [ ] **F3.1** useZoom / useTheme
 - [ ] **F3.2** useThreading / useAttachments / useRsvp


### PR DESCRIPTION
## 📋 Description

First batch of the `App.tsx` decomposition plan (`docs/DESKTOP_REFACTOR_PLAN.md`). Stands up the **first frontend test harness ever** and peels the lowest-risk pure logic out of the 5.7k-line god component. **Zero behavior change.**

- **F0 — Harness:** vitest + jsdom, `vitest.config.ts` (jsdom env), `npm test` script.
- **F1 — Pure helpers:** `format.ts` (11 formatting/parsing fns) + `compose.ts` (reply/reply-all/forward builders), extracted from `App.tsx` and unit-tested.
- **F2 — Command layer:** `commands.ts` — the `COMMANDS` table plus pure `parseCommand` / `filterCommands` / `resolveEnter`. `CommandBar` and `App.executeCommand` now call the shared helpers. The big `executeCommand` switch stays as the handler adapter (data-driven dispatch deferred — low value, higher risk).

`App.tsx`: **5,747 → 5,512** lines. New test suites: **38 unit tests**.

Scope note: Playwright integration tests protect the *coupled* refactors (F3 hooks); this batch is pure/near-pure, so it's covered by unit tests. The Playwright suite gets built at the start of F3.

## 🧪 Testing
- [x] `npm test` — 38 tests passing (format 23, compose 6, commands 9, + COMMANDS integrity check)
- [x] `npx tsc --noEmit` clean, `npm run build` clean
- [x] Playwright command-bar smoke: alias runs, prefix resolves to highlighted, `:p` opens the picker, `:theme` is **not** auto-actioned by the Enter that opened it (the delicate `stopPropagation` behavior preserved)
- [x] No behavior change (extractions + rewiring only)

## 📝 Related
Executes F0–F2 of `docs/DESKTOP_REFACTOR_PLAN.md`. F3 (subsystem hooks, incl. the AI panels) is deferred to dedicated sessions with Playwright in front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU)_