### PR TITLE
docs: persist refactor state + backlog for session handoff

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -67,7 +67,23 @@ action-plan, …) MUST follow these so they behave consistently:
 
 ## ✅ Verify before claiming done
 
+- `cd desktop/frontend && npm test` (vitest unit tests — the frontend now has them)
 - `cd desktop/frontend && npx tsc --noEmit && npm run build`
 - `go build ./pkg/desktop/ && (cd desktop && go build ./...) && go test ./pkg/desktop/`
 - Drive the change in a browser against the mock (Playwright + the pre-installed
   Chromium) — pickers especially: open via command, arrow-navigate, Enter, Escape.
+
+## 🧱 Ongoing: `App.tsx` decomposition (READ if touching App.tsx)
+
+`App.tsx` is a large god component being broken up incrementally. Pure logic
+already lives in small, unit-tested modules — **use/extend these, don't re-inline**:
+`format.ts` (formatting/parsing), `compose.ts` (reply/forward builders),
+`commands.ts` (`COMMANDS` + palette resolution). Add tests next to new pure logic.
+
+**The plan, progress tracker, and — critically — the coupling landmines that keep
+causing bugs (`openIdRef`, `summaryForId`/`promptForId`, `loadMessage` as
+`useCallback([])`, mirror refs, first-binding-wins chords, the `anyModal` Escape
+order) live in [`docs/DESKTOP_REFACTOR_PLAN.md`](../docs/DESKTOP_REFACTOR_PLAN.md).
+Read it before extracting anything stateful.** Next up is F3 (subsystem hooks);
+stand up a Playwright integration suite FIRST — it's the only net for the coupled
+behavior (AI panels are the riskiest, do them last).

--- a/docs/DESKTOP_REFACTOR_PLAN.md
+++ b/docs/DESKTOP_REFACTOR_PLAN.md
@@ -7,8 +7,16 @@
 > assistant's ephemeral context) so a fresh session, or a human, can pick it up
 > mid-flight. Update the **Progress tracker** as phases land.
 
-**Status:** APPROVED — executing F0 → F1 → F2 this batch (F3 hooks deferred).
+**Status:** F0–F2 DONE & merged (PR #61). Approach approved.
 **Owner:** _tbd_ · **Last updated:** 2026-07-25
+
+> **▶ RESUME HERE (next session).** F0–F2 are merged: vitest harness + `format.ts`,
+> `compose.ts`, `commands.ts` extracted (38 unit tests; `npm test`). **Next is F3
+> (subsystem hooks) — but FIRST build the Playwright integration suite** (§5), the
+> only net for the coupled behavior; then extract hooks safest→riskiest with
+> `useAiPanels` LAST. Re-read §3 (landmines) before touching any stateful code.
+> The branch `claude/giztui-visual-client-iadjgl` was reset off `main` after each
+> merge — reset it to latest `main` again before starting.
 
 > **Sequencing note (refinement, approved):** Playwright integration tests protect
 > the *coupled* refactors (F3). F1/F2 are pure/near-pure and are protected by unit
@@ -162,9 +170,20 @@ Extract **as behavior-preserving moves**, safest → riskiest, Playwright in fro
 4. Stop before F3 unless F0 is done and Playwright is protecting the flow.
 5. If a step can't preserve a §3 landmine contract, abandon that step and rethink.
 
-## 9. Open decisions (needed before executing)
+## 9. Open decisions
 
-- [ ] Approve **vitest + jsdom** as the unit harness.
-- [ ] Confirm order: **F0 → F1 → F2 this batch; F3 (hooks) in dedicated sessions.**
+- [x] vitest + jsdom approved as the unit harness.
+- [x] Order approved: F0 → F1 → F2 this batch; F3 (hooks) in dedicated sessions.
 - [ ] Where do Playwright specs live (`desktop/frontend/e2e/`?) and do we wire them
-  into CI or keep them local-run for now?
+  into CI or keep them local-run for now? (decide at F3 start)
+
+## 10. Related outstanding work (NOT this plan — separate backlog)
+
+- [ ] Add repo secret **`HOMEBREW_TAP_TOKEN`** (contents:write on
+  `ajramos/homebrew-giztui`) so `release-desktop.yml`'s cask auto-bump runs.
+- [ ] macOS **notarization** + Windows signing (phase 2 in `DESKTOP_DISTRIBUTION.md`)
+  — the biggest user-facing friction (Gatekeeper/SmartScreen on unsigned builds).
+- [ ] Product decision: keep or remove **`:touch-up`** (user finds it unclear).
+- [ ] Minor TUI↔desktop command-parity gaps (`:numbers`, `:preload`, bookmarks).
+- [ ] Coverage baseline (2026-07-25): Go `internal/services` 32%, `pkg/desktop` 24%,
+  `internal/tui` 9.7%; **frontend bootstrapped 0 → 38 unit tests**.


### PR DESCRIPTION
## 📋 Description

Docs-only. Persists enough state to `main` that a fresh session resumes the `App.tsx` decomposition without re-discovery.

- `desktop/CLAUDE.md`: adds `npm test` to the verify checklist, points at the extracted pure modules (`format.ts` / `compose.ts` / `commands.ts`), and links the decomposition plan + coupling landmines to read before touching stateful code.
- `docs/DESKTOP_REFACTOR_PLAN.md`: a **▶ RESUME HERE** pointer (F0–F2 done, F3 next, build Playwright suite first), and a **§10 related backlog** (HOMEBREW_TAP_TOKEN secret, notarization, `:touch-up` decision, parity gaps, coverage baseline) so nothing is lost.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU)_