### PR TITLE
refactor(desktop): Playwright net + extract zoom/theme/attachments/rsvp/threading hooks (F3.0–F3.2)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -68,6 +68,9 @@ action-plan, …) MUST follow these so they behave consistently:
 ## ✅ Verify before claiming done
 
 - `cd desktop/frontend && npm test` (vitest unit tests — the frontend now has them)
+- `cd desktop/frontend && npm run test:e2e` (Playwright integration suite in `e2e/`
+  — drives the real app against the api.ts mock; the regression net for the App.tsx
+  decomposition. Extend it when you add/refactor a coupled flow.)
 - `cd desktop/frontend && npx tsc --noEmit && npm run build`
 - `go build ./pkg/desktop/ && (cd desktop && go build ./...) && go test ./pkg/desktop/`
 - Drive the change in a browser against the mock (Playwright + the pre-installed

--- a/desktop/frontend/.gitignore
+++ b/desktop/frontend/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 dist/
+test-results/
+playwright-report/

--- a/desktop/frontend/e2e/ai-panels.spec.ts
+++ b/desktop/frontend/e2e/ai-panels.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from "@playwright/test";
+import {
+  openApp,
+  openMessageAt,
+  promptPanel,
+  runCommand,
+  summaryPanel,
+  waitForPanelDone,
+} from "./helpers";
+
+// These flows are the ones the refactor plan (§3 landmines) calls out as the
+// source of the coupling bugs: an AI run must belong to the message it was
+// launched on (summaryForId / promptForId / openIdRef), the per-message result
+// is cached and restored on return, and a run started on one message must never
+// paint into another. This is the primary net for the useAiPanels extraction.
+
+test.describe("AI summary panel", () => {
+  test("':summarize' streams a summary into the reader", async ({ page }) => {
+    await openApp(page);
+    await openMessageAt(page, 0);
+
+    await runCommand(page, "summarize");
+    await expect(summaryPanel(page)).toBeVisible();
+    await expect(summaryPanel(page).locator(".summary-head")).toContainText("AI summary");
+    const text = await waitForPanelDone(summaryPanel(page));
+    expect(text.length).toBeGreaterThan(0);
+  });
+
+  test("summary is per-message: cached on return, absent on a fresh message", async ({
+    page,
+  }) => {
+    await openApp(page);
+
+    // Summarize message A and let it finish streaming.
+    await openMessageAt(page, 0);
+    await runCommand(page, "summarize");
+    const summaryA = await waitForPanelDone(summaryPanel(page));
+    expect(summaryA.length).toBeGreaterThan(0);
+
+    // Switch to message B — its summary was never generated, so no panel bleeds
+    // over from A.
+    await openMessageAt(page, 1);
+    await expect(summaryPanel(page)).toBeHidden();
+
+    // Return to A — the cached summary is restored, unchanged.
+    await openMessageAt(page, 0);
+    await expect(summaryPanel(page)).toBeVisible();
+    await expect(summaryPanel(page).locator(".summary-text")).toHaveText(summaryA);
+  });
+
+  test("'dismiss' hides the open summary panel", async ({ page }) => {
+    await openApp(page);
+    await openMessageAt(page, 0);
+    await runCommand(page, "summarize");
+    // Wait for the run to complete before dismissing (dismiss is a post-run action).
+    await waitForPanelDone(summaryPanel(page));
+
+    await runCommand(page, "dismiss");
+    await expect(summaryPanel(page)).toBeHidden();
+  });
+});
+
+test.describe("AI prompt panel", () => {
+  test("applying a prompt shows a result that survives switch + return", async ({
+    page,
+  }) => {
+    await openApp(page);
+    await openMessageAt(page, 0);
+
+    // ':prompt' opens the prompts picker; Enter runs the highlighted prompt.
+    await runCommand(page, "prompt");
+    await expect(page.locator(".modal-overlay")).toBeVisible();
+    await page.keyboard.press("Enter");
+
+    await expect(promptPanel(page)).toBeVisible();
+    const promptA = await waitForPanelDone(promptPanel(page));
+    expect(promptA.length).toBeGreaterThan(0);
+
+    // Switch away — the prompt result must not paint onto message B.
+    await openMessageAt(page, 1);
+    await expect(promptPanel(page)).toBeHidden();
+
+    // Return to A — the cached prompt result is restored.
+    await openMessageAt(page, 0);
+    await expect(promptPanel(page)).toBeVisible();
+    await expect(promptPanel(page).locator(".summary-text")).toHaveText(promptA);
+  });
+});

--- a/desktop/frontend/e2e/attachments.spec.ts
+++ b/desktop/frontend/e2e/attachments.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+import { openApp, openMessageAt, runCommand } from "./helpers";
+
+// Guards the useAttachments extraction (F3.2): the attachment list is fetched
+// per-message inside loadMessage (gated by openIdRef) and shown as chips; the
+// ':attachments' command opens the keyboard-navigable picker. In the mock,
+// message m0 (row 0) carries two attachments.
+test.describe("attachments", () => {
+  test("the attachment bar shows the message's attachments", async ({ page }) => {
+    await openApp(page);
+    await openMessageAt(page, 0);
+    await expect(page.locator(".attach-bar")).toBeVisible();
+    await expect(page.locator(".attach-chip")).toHaveCount(2);
+    await expect(page.locator(".attach-chip").first()).toContainText(
+      "invoice-2043.pdf",
+    );
+  });
+
+  test("':attachments' opens the picker and Escape closes it", async ({ page }) => {
+    await openApp(page);
+    await openMessageAt(page, 0);
+    await expect(page.locator(".attach-bar")).toBeVisible();
+
+    await runCommand(page, "attachments");
+    await expect(page.locator(".modal-overlay")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.locator(".modal-overlay")).toBeHidden();
+  });
+});

--- a/desktop/frontend/e2e/helpers.ts
+++ b/desktop/frontend/e2e/helpers.ts
@@ -1,0 +1,56 @@
+import { type Page, type Locator, expect } from "@playwright/test";
+
+// Shared helpers for driving the desktop app through its command palette and
+// message list — the two stable entry points that survive the App.tsx
+// decomposition. Prefer commands over raw shortcuts: the COMMANDS table is the
+// documented contract and is far less brittle than key-by-key bindings.
+
+export const rows = (page: Page): Locator => page.locator(".row");
+export const summaryPanel = (page: Page): Locator =>
+  page.locator(".summary-panel:not(.prompt-panel)");
+export const promptPanel = (page: Page): Locator =>
+  page.locator(".summary-panel.prompt-panel");
+
+// openApp navigates to the app and waits for the mock inbox to render.
+export async function openApp(page: Page): Promise<void> {
+  await page.goto("/");
+  await expect(rows(page).first()).toBeVisible();
+}
+
+// runCommand opens the ":" command palette, types a command, and submits it.
+// Assumes no text input currently holds focus (the normal state between flows).
+export async function runCommand(page: Page, command: string): Promise<void> {
+  await page.keyboard.press(":");
+  const input = page.locator(".cmd-input");
+  await expect(input).toBeVisible();
+  await input.fill(command);
+  await page.keyboard.press("Enter");
+  // The palette closes itself on submit; wait for it so the next window-level
+  // keypress (a following ":" or shortcut) isn't swallowed by the closing modal.
+  await expect(page.locator(".cmd-bar")).toBeHidden();
+}
+
+// openMessageAt clicks the Nth message row and waits for the reader to show it.
+export async function openMessageAt(page: Page, index: number): Promise<string> {
+  const row = rows(page).nth(index);
+  const subject = (await row.locator(".subject").first().textContent())?.trim() ?? "";
+  await row.click();
+  await expect(page.locator(".reader-head h2")).toHaveText(subject);
+  return subject;
+}
+
+// readerSubject returns the subject currently shown in the reading pane.
+export async function readerSubject(page: Page): Promise<string> {
+  return (await page.locator(".reader-head h2").textContent())?.trim() ?? "";
+}
+
+// waitForPanelDone waits until an AiPanel has finished streaming. AiPanel only
+// renders its regenerate/dismiss actions once `text !== null && !generating`, so
+// the presence of the "regenerate" button is the reliable "done" signal — the
+// streaming caret (▍) is gone and the text is final.
+export async function waitForPanelDone(panel: Locator): Promise<string> {
+  await expect(
+    panel.locator(".summary-head-actions button", { hasText: "regenerate" }),
+  ).toBeVisible();
+  return (await panel.locator(".summary-text").textContent())?.trim() ?? "";
+}

--- a/desktop/frontend/e2e/inbox.spec.ts
+++ b/desktop/frontend/e2e/inbox.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test";
+import { openApp, openMessageAt, rows, runCommand } from "./helpers";
+
+test.describe("inbox + reader", () => {
+  test("renders the mock inbox and opens a message in the reader", async ({ page }) => {
+    await openApp(page);
+    await expect(rows(page)).toHaveCount(24);
+
+    const subject = await openMessageAt(page, 0);
+    expect(subject).toBe("Welcome to GizTUI Desktop");
+    // Reader body renders the full message content from the mock.
+    await expect(page.locator(".reader-body")).toBeVisible();
+    await expect(page.locator(".reader-body")).toContainText(subject);
+  });
+
+  test("switching rows swaps the reader content", async ({ page }) => {
+    await openApp(page);
+    await openMessageAt(page, 0);
+    await expect(page.locator(".reader-head h2")).toHaveText("Welcome to GizTUI Desktop");
+
+    await openMessageAt(page, 2);
+    await expect(page.locator(".reader-head h2")).toHaveText("Re: Project roadmap Q3");
+  });
+
+  test("the command palette opens with ':' and closes on Escape", async ({ page }) => {
+    await openApp(page);
+    await page.keyboard.press(":");
+    await expect(page.locator(".cmd-bar")).toBeVisible();
+    // The input auto-focuses so typing filters immediately.
+    await expect(page.locator(".cmd-input")).toBeFocused();
+    await page.keyboard.press("Escape");
+    await expect(page.locator(".cmd-bar")).toBeHidden();
+  });
+
+  test("'load more' is a no-op on the mock but does not break the list", async ({ page }) => {
+    await openApp(page);
+    await runCommand(page, "inbox");
+    await expect(rows(page)).toHaveCount(24);
+  });
+});

--- a/desktop/frontend/e2e/pickers.spec.ts
+++ b/desktop/frontend/e2e/pickers.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "@playwright/test";
+import { openApp, openMessageAt, runCommand } from "./helpers";
+
+// Pickers are keyboard-first and driven by window-level listeners (WKWebView
+// won't focus a bare div). The refactor must keep: open via command, arrow
+// navigation updating the active row, and Escape closing from anywhere.
+
+test.describe("pickers", () => {
+  test("':labels' opens the labels picker and Escape closes it", async ({ page }) => {
+    await openApp(page);
+    await openMessageAt(page, 0);
+
+    await runCommand(page, "labels");
+    await expect(page.locator(".modal-overlay")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page.locator(".modal-overlay")).toBeHidden();
+  });
+
+  test("arrow keys move the active row in a picker", async ({ page }) => {
+    await openApp(page);
+    await openMessageAt(page, 0);
+
+    await runCommand(page, "labels");
+    await expect(page.locator(".modal-overlay")).toBeVisible();
+
+    const active = page.locator(".modal-overlay .nav-active");
+    await expect(active).toHaveCount(1);
+    const first = (await active.textContent())?.trim();
+
+    await page.keyboard.press("ArrowDown");
+    const moved = (await page.locator(".modal-overlay .nav-active").textContent())?.trim();
+    expect(moved).not.toBe(first);
+
+    await page.keyboard.press("Escape");
+    await expect(page.locator(".modal-overlay")).toBeHidden();
+  });
+
+  test("':theme' opens the theme picker and Escape closes it", async ({ page }) => {
+    await openApp(page);
+
+    await runCommand(page, "theme");
+    await expect(page.locator(".modal-overlay")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page.locator(".modal-overlay")).toBeHidden();
+  });
+});

--- a/desktop/frontend/e2e/rsvp.spec.ts
+++ b/desktop/frontend/e2e/rsvp.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+import { openApp, openMessageAt, runCommand } from "./helpers";
+
+// Guards the useRsvp extraction (F3.2): the invite is fetched per-message inside
+// loadMessage (gated by openIdRef + the enabled ref) and surfaced as the RSVP
+// bar; ':rsvp' opens the picker; responding calls the backend and toasts. In the
+// mock, message m0 (row 0) is a calendar invite.
+test.describe("RSVP", () => {
+  test("the RSVP bar shows for a calendar invite", async ({ page }) => {
+    await openApp(page);
+    await openMessageAt(page, 0);
+    await expect(page.locator(".rsvp-bar")).toBeVisible();
+    await expect(page.locator(".rsvp-btn.accept")).toBeVisible();
+    await expect(page.locator(".rsvp-btn.decline")).toBeVisible();
+  });
+
+  test("':rsvp' opens the RSVP picker and Escape closes it", async ({ page }) => {
+    await openApp(page);
+    await openMessageAt(page, 0);
+    await expect(page.locator(".rsvp-bar")).toBeVisible();
+
+    await runCommand(page, "rsvp");
+    await expect(page.locator(".modal-overlay")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.locator(".modal-overlay")).toBeHidden();
+  });
+
+  test("responding to an invite confirms with a toast", async ({ page }) => {
+    await openApp(page);
+    await openMessageAt(page, 0);
+    await expect(page.locator(".rsvp-bar")).toBeVisible();
+
+    await page.locator(".rsvp-btn.accept").click();
+    await expect(page.locator(".toast")).toContainText("RSVP: accepted");
+  });
+});

--- a/desktop/frontend/e2e/search.spec.ts
+++ b/desktop/frontend/e2e/search.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+import { openApp, rows, runCommand } from "./helpers";
+
+test.describe("search scoping", () => {
+  test("':search' scopes the list and ':inbox' restores it", async ({ page }) => {
+    await openApp(page);
+    await expect(rows(page)).toHaveCount(24);
+
+    // The mock matches subject/from substrings; 4 of the 24 are invoices.
+    await runCommand(page, "search invoice");
+    await expect(rows(page)).toHaveCount(4);
+    await expect(rows(page).first().locator(".subject")).toHaveText(
+      "Invoice #2043 from Acme Corp",
+    );
+
+    await runCommand(page, "inbox");
+    await expect(rows(page)).toHaveCount(24);
+  });
+
+  test("a search with no matches yields an empty list, and inbox recovers", async ({
+    page,
+  }) => {
+    await openApp(page);
+    await runCommand(page, "search zzz-no-such-subject");
+    await expect(rows(page)).toHaveCount(0);
+
+    await runCommand(page, "inbox");
+    await expect(rows(page)).toHaveCount(24);
+  });
+});

--- a/desktop/frontend/e2e/theme.spec.ts
+++ b/desktop/frontend/e2e/theme.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect, type Page } from "@playwright/test";
+import { openApp, runCommand } from "./helpers";
+
+// Guards the useTheme extraction (F3.1): the startup init applies the configured
+// theme, and ':theme <name>' maps that theme's palette onto the CSS custom
+// properties the stylesheet reads. The mock resolves an empty/unknown name to
+// "slate-blue" and defines "dracula".
+const cssVar = (page: Page, name: string) =>
+  page.evaluate(
+    (n) => getComputedStyle(document.documentElement).getPropertyValue(n).trim(),
+    name,
+  );
+
+test.describe("theme", () => {
+  test("startup applies the configured theme's palette", async ({ page }) => {
+    await openApp(page);
+    // Empty name resolves to slate-blue in the mock backend.
+    expect(await cssVar(page, "--bg")).toBe("#0f172a");
+  });
+
+  test("':theme <name>' applies that theme's colors", async ({ page }) => {
+    await openApp(page);
+    await runCommand(page, "theme dracula");
+    expect(await cssVar(page, "--bg")).toBe("#282a36");
+    expect(await cssVar(page, "--accent")).toBe("#bd93f9");
+  });
+
+  test("':theme' with no arg opens the picker; Escape closes it", async ({ page }) => {
+    await openApp(page);
+    await runCommand(page, "theme");
+    await expect(page.locator(".modal-overlay")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.locator(".modal-overlay")).toBeHidden();
+  });
+});

--- a/desktop/frontend/e2e/threading.spec.ts
+++ b/desktop/frontend/e2e/threading.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "@playwright/test";
+import { openApp, openMessageAt, runCommand, summaryPanel } from "./helpers";
+
+// Guards the useThreading extraction (F3.2): ':threads' toggles the conversation
+// view, and ':thread-summary' is gated on the loaded thread (threadMsgs, now
+// owned by the hook) before calling summarizeThread (which still lives in App).
+// The mock returns a 3-message thread.
+test.describe("threading", () => {
+  test("':threads' toggles the conversation view", async ({ page }) => {
+    await openApp(page);
+    await openMessageAt(page, 2); // "Re: Project roadmap Q3"
+
+    await runCommand(page, "threads");
+    await expect(page.locator(".reader-body")).toContainText(
+      "Conversation · 3 messages",
+    );
+
+    await runCommand(page, "threads");
+    await expect(page.locator(".reader-body")).not.toContainText(
+      "Conversation · 3 messages",
+    );
+  });
+
+  test("':thread-summary' summarizes the open thread", async ({ page }) => {
+    await openApp(page);
+    await openMessageAt(page, 2);
+    await runCommand(page, "threads");
+    await expect(page.locator(".reader-body")).toContainText(
+      "Conversation · 3 messages",
+    );
+
+    await runCommand(page, "thread-summary");
+    await expect(summaryPanel(page)).toBeVisible();
+    await expect(summaryPanel(page).locator(".summary-text")).toContainText(
+      "roadmap",
+    );
+  });
+});

--- a/desktop/frontend/e2e/zoom.spec.ts
+++ b/desktop/frontend/e2e/zoom.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "@playwright/test";
+import { openApp, rows, runCommand } from "./helpers";
+
+// Guards the useZoom extraction (F3.1): zoom is CSS `zoom` on the document root,
+// clamped/rounded, and persisted to localStorage across reloads.
+const rootZoom = (page: import("@playwright/test").Page) =>
+  page.evaluate(() => document.documentElement.style.zoom || "");
+
+test.describe("UI zoom", () => {
+  test("zoom commands change the root CSS zoom", async ({ page }) => {
+    await openApp(page);
+
+    await runCommand(page, "zoom-reset");
+    expect(await rootZoom(page)).toBe("1");
+
+    await runCommand(page, "zoom-in");
+    expect(await rootZoom(page)).toBe("1.1");
+
+    await runCommand(page, "zoom-out");
+    expect(await rootZoom(page)).toBe("1");
+
+    // ':zoom <n>' sets an absolute level; ':zoom' with no arg resets.
+    await runCommand(page, "zoom 1.5");
+    expect(await rootZoom(page)).toBe("1.5");
+    await runCommand(page, "zoom");
+    expect(await rootZoom(page)).toBe("1");
+  });
+
+  test("zoom persists across a reload", async ({ page }) => {
+    await openApp(page);
+    await runCommand(page, "zoom 1.3");
+    expect(await rootZoom(page)).toBe("1.3");
+
+    await page.reload();
+    await expect(rows(page).first()).toBeVisible();
+    expect(await rootZoom(page)).toBe("1.3");
+
+    // Restore so a reused context doesn't leak a zoom into later work.
+    await runCommand(page, "zoom-reset");
+  });
+});

--- a/desktop/frontend/package-lock.json
+++ b/desktop/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.56.1",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
@@ -879,6 +880,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
+      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2312,6 +2329,53 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.19",

--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "dompurify": "^3.4.12",
@@ -16,6 +17,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.56.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",

--- a/desktop/frontend/playwright.config.ts
+++ b/desktop/frontend/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from "@playwright/test";
+
+// Playwright integration suite for the desktop frontend.
+//
+// This is the regression net that guards the F3 refactor (extracting the
+// coupled subsystem hooks out of App.tsx). It drives the REAL React app against
+// the in-browser api.ts mock backend — the same mock `npm run dev` uses — so it
+// exercises the coupled runtime behavior (window-level key listeners, streaming
+// order, focus, the summary/prompt ForId gating) that jsdom unit tests cannot.
+//
+// Chromium comes from the pre-installed browser (PLAYWRIGHT_BROWSERS_PATH is set
+// in this environment); we never download one. Run with `npm run test:e2e`.
+const PORT = 5199;
+
+export default defineConfig({
+  testDir: "./e2e",
+  // The flows share one mock backend and mutate it (labels, trash); keep them
+  // serial and deterministic rather than racing parallel workers.
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 1 : 0,
+  timeout: 30_000,
+  expect: { timeout: 8_000 },
+  reporter: [["list"]],
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    trace: "retain-on-failure",
+    viewport: { width: 1280, height: 850 },
+  },
+  projects: [{ name: "chromium", use: { browserName: "chromium" } }],
+  webServer: {
+    command: `npm run dev -- --port ${PORT} --strictPort`,
+    url: `http://localhost:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 90_000,
+  },
+});

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -69,6 +69,7 @@ import { useZoom } from "./useZoom";
 import { useTheme } from "./useTheme";
 import { useAttachments } from "./useAttachments";
 import { useRsvp } from "./useRsvp";
+import { useThreading } from "./useThreading";
 import { Icon, IconBtn } from "./Icons";
 
 const PAGE_SIZE = 50;
@@ -205,10 +206,6 @@ export default function App() {
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [loadingSuggest, setLoadingSuggest] = useState(false);
   const [cmdOpen, setCmdOpen] = useState(false);
-  const [threadingOn, setThreadingOn] = useState(false);
-  const [threadMsgs, setThreadMsgs] = useState<MessageDetail[] | null>(null);
-  const [collapsedMsgs, setCollapsedMsgs] = useState<Set<string>>(new Set());
-  const [loadingThread, setLoadingThread] = useState(false);
   const [savedQueriesOn, setSavedQueriesOn] = useState(false);
   const [queriesOpen, setQueriesOpen] = useState(false);
   const [savedQueries, setSavedQueries] = useState<SavedQuery[]>([]);
@@ -414,6 +411,16 @@ export default function App() {
     setRsvpPickerOpen,
     respondInvite,
   } = useRsvp({ setError, showToast });
+  const {
+    threadingOn,
+    setThreadingOn,
+    threadMsgs,
+    setThreadMsgs,
+    collapsedMsgs,
+    setCollapsedMsgs,
+    loadingThread,
+    toggleThread,
+  } = useThreading(detail, { setError });
 
   // When an AI result panel starts, reveal it (the panels render at the top of
   // the reader, so if you'd scrolled down they'd appear above the fold and look
@@ -1705,24 +1712,6 @@ export default function App() {
     },
     [suggestFor, showToast],
   );
-
-  const toggleThread = useCallback(async () => {
-    if (!detail) return;
-    if (threadMsgs) {
-      setThreadMsgs(null);
-      return;
-    }
-    setLoadingThread(true);
-    setError("");
-    try {
-      const msgs = await backend.GetThread(detail.threadId);
-      setThreadMsgs(msgs);
-    } catch (e) {
-      setError(String(e));
-    } finally {
-      setLoadingThread(false);
-    }
-  }, [detail, threadMsgs]);
 
   const summarizeThread = useCallback(async () => {
     if (!detail) return;

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -8,11 +8,9 @@ import {
   summarizeStream,
   threadSummaryStream,
   type AccountInfo,
-  type Attachment,
   type DraftSummary,
   type KeyMap,
   type Label,
-  type Invite,
   type UsageStats,
   type ConfigInfo,
   type MessageDetail,
@@ -69,6 +67,8 @@ import MoreMenu from "./MoreMenu";
 import { useListNav } from "./useListNav";
 import { useZoom } from "./useZoom";
 import { useTheme } from "./useTheme";
+import { useAttachments } from "./useAttachments";
+import { useRsvp } from "./useRsvp";
 import { Icon, IconBtn } from "./Icons";
 
 const PAGE_SIZE = 50;
@@ -92,8 +92,6 @@ export default function App() {
   const [pendingNew, setPendingNew] = useState<MessageSummary[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [detail, setDetail] = useState<MessageDetail | null>(null);
-  const [attachments, setAttachments] = useState<Attachment[]>([]);
-  const [attachmentsOpen, setAttachmentsOpen] = useState(false);
   // Whether keyboard focus is "in" the reader: after Enter/click-open (or a click
   // inside the reader) the arrow/j/k keys scroll the message instead of moving
   // the inbox cursor. Escape returns focus to the list. Mirrors the TUI, where
@@ -292,18 +290,10 @@ export default function App() {
   const runningLabelRef = useRef<Record<string, string>>({});
   const touchUpTextRef = useRef(touchUpText);
   touchUpTextRef.current = touchUpText;
-  const [rsvpEnabled, setRsvpEnabled] = useState(false);
-  const [invite, setInvite] = useState<Invite | null>(null);
-  const [rsvpBusy, setRsvpBusy] = useState("");
   const [statsOpen, setStatsOpen] = useState(false);
   const [stats, setStats] = useState<UsageStats | null>(null);
   const [configOpen, setConfigOpen] = useState(false);
   const [configInfo, setConfigInfo] = useState<ConfigInfo | null>(null);
-  // Ref mirror so loadMessage (stable, no deps) can read the latest value.
-  const rsvpEnabledRef = useRef(false);
-  useEffect(() => {
-    rsvpEnabledRef.current = rsvpEnabled;
-  }, [rsvpEnabled]);
   // headersExpanded reveals the extra cc/thread/id detail (via the ⋯ menu).
   // headersHidden collapses the whole From/To/Date block for more body room and
   // is what the `h` key toggles, matching the TUI's toggle_headers.
@@ -315,8 +305,6 @@ export default function App() {
   const [csOpen, setCsOpen] = useState(false);
   const [csQuery, setCsQuery] = useState("");
   const [csIndex, setCsIndex] = useState(0);
-  // The RSVP bar auto-shows for invites; V opens a keyboard-navigable picker.
-  const [rsvpPickerOpen, setRsvpPickerOpen] = useState(false);
   // The reader toolbar is optional — GizTUI is keyboard-first, so users can
   // hide it and drive everything from the keyboard. The choice is persisted.
   const [showToolbar, setShowToolbar] = useState(
@@ -404,6 +392,28 @@ export default function App() {
     setToast(msg);
     setTimeout(() => setToast(""), 2500);
   }, []);
+
+  // Per-message subsystems extracted from App.tsx (F3.2). Their per-message data
+  // is still fetched inside loadMessage (gated by openIdRef) via the setters
+  // below; the hooks own the state + standalone actions.
+  const {
+    attachments,
+    setAttachments,
+    attachmentsOpen,
+    setAttachmentsOpen,
+    downloadAttachment,
+  } = useAttachments(detail, { setBusy, setError, showToast });
+  const {
+    rsvpEnabled,
+    setRsvpEnabled,
+    rsvpEnabledRef,
+    invite,
+    setInvite,
+    rsvpBusy,
+    rsvpPickerOpen,
+    setRsvpPickerOpen,
+    respondInvite,
+  } = useRsvp({ setError, showToast });
 
   // When an AI result panel starts, reveal it (the panels render at the top of
   // the reader, so if you'd scrolled down they'd appear above the fold and look
@@ -1319,23 +1329,6 @@ export default function App() {
     }
   }, [updateAiCache]);
 
-  // respondInvite sends an RSVP (accepted/tentative/declined) for the open
-  // message's calendar invite.
-  const respondInvite = useCallback(
-    async (id: string, status: "accepted" | "tentative" | "declined") => {
-      setRsvpBusy(status);
-      setError("");
-      try {
-        await backend.RespondInvite(id, status);
-        showToast(`RSVP: ${status}`);
-      } catch (e) {
-        setError(String(e));
-      } finally {
-        setRsvpBusy("");
-      }
-    },
-    [showToast],
-  );
 
   const openStats = useCallback(async () => {
     setStatsOpen(true);
@@ -2676,26 +2669,6 @@ export default function App() {
       resetZoom,
       setZoom,
     ],
-  );
-
-  const downloadAttachment = useCallback(
-    async (att: Attachment) => {
-      if (!detail) return;
-      setBusy(true);
-      try {
-        const path = await backend.DownloadAttachment(
-          detail.id,
-          att.attachmentId,
-          att.filename,
-        );
-        showToast(`Saved to ${path}`);
-      } catch (e) {
-        setError(String(e));
-      } finally {
-        setBusy(false);
-      }
-    },
-    [detail, showToast],
   );
 
   // Invert the (config-driven) keymap into a chord → action lookup. gotoTop is

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -44,7 +44,6 @@ import {
   emailAddr,
   labelForAction,
   formatICSDate,
-  mixHex,
   cleanSubject,
   countMatches,
   formatDate,
@@ -68,6 +67,8 @@ import CommandBar from "./CommandBar";
 import { COMMANDS, parseCommand } from "./commands";
 import MoreMenu from "./MoreMenu";
 import { useListNav } from "./useListNav";
+import { useZoom } from "./useZoom";
+import { useTheme } from "./useTheme";
 import { Icon, IconBtn } from "./Icons";
 
 const PAGE_SIZE = 50;
@@ -256,10 +257,16 @@ export default function App() {
   const [newRule, setNewRule] = useState("");
   const [promptPreview, setPromptPreview] = useState<string | null>(null);
   const promptPreviewBodyRef = useRef<HTMLDivElement>(null);
-  const [themesOn, setThemesOn] = useState(false);
-  const [themePickerOpen, setThemePickerOpen] = useState(false);
-  const [themeNames, setThemeNames] = useState<string[]>([]);
-  const [currentTheme, setCurrentTheme] = useState("");
+  // Theme subsystem (enablement, names, current, picker, applyTheme) lives in useTheme.
+  const {
+    themesOn,
+    themePickerOpen,
+    setThemePickerOpen,
+    themeNames,
+    currentTheme,
+    applyTheme,
+    initTheme,
+  } = useTheme();
   const [generatingReply, setGeneratingReply] = useState(false);
   const [touchUpText, setTouchUpText] = useState<string | null>(null);
   const [touchingUp, setTouchingUp] = useState(false);
@@ -315,21 +322,8 @@ export default function App() {
   const [showToolbar, setShowToolbar] = useState(
     () => localStorage.getItem("giztui.toolbar") !== "off",
   );
-  // UI zoom: WKWebView doesn't honour Cmd+/- to scale the app, so we drive it
-  // ourselves via CSS zoom on the root and remember the choice. Cmd/Ctrl +/-/0.
-  const [uiZoom, setUiZoom] = useState(() => {
-    const v = Number(localStorage.getItem("giztui.zoom"));
-    return v >= 0.6 && v <= 2.4 ? v : 1;
-  });
-  useEffect(() => {
-    (document.documentElement.style as unknown as { zoom: string }).zoom =
-      String(uiZoom);
-    localStorage.setItem("giztui.zoom", String(uiZoom));
-  }, [uiZoom]);
-  const bumpZoom = useCallback((delta: number) => {
-    setUiZoom((z) => Math.min(2.4, Math.max(0.6, Math.round((z + delta) * 10) / 10)));
-  }, []);
-  const resetZoom = useCallback(() => setUiZoom(1), []);
+  // UI zoom (Cmd/Ctrl +/-/0) lives in useZoom — CSS `zoom` on the root, persisted.
+  const { setZoom, bumpZoom, resetZoom } = useZoom();
   // Local filter mode: narrow the already-loaded list client-side instead of
   // running a remote Gmail search (the TUI's search_toggle_mode).
   const [localFilter, setLocalFilter] = useState(false);
@@ -448,57 +442,6 @@ export default function App() {
     },
     [showToast],
   );
-
-  // applyTheme fetches a theme's palette from the backend and maps it onto the
-  // CSS custom properties the stylesheet reads. Empty name = the configured
-  // (current) theme, resolved on startup.
-  const applyTheme = useCallback(async (name: string) => {
-    try {
-      const c = await backend.GetThemeColors(name);
-      if (!c) return;
-      const root = document.documentElement.style;
-      const set = (k: string, v: string) => {
-        if (v) root.setProperty(k, v);
-      };
-      // Map the theme palette onto the CSS custom properties the stylesheet
-      // reads. Elevated/hover surfaces are derived from the base background so
-      // the UI keeps its layering even when a theme only defines a few colors.
-      // The accent (focus color) — never the title color — drives buttons, so
-      // primary buttons stay in the theme's accent hue instead of turning into
-      // a loud title color (e.g. bright green).
-      const bg = c.bg || "#14161b";
-      const fg = c.fg || "#e6e8ec";
-      const accent = c.accent || "#6ea8fe";
-      const distinct = (v: string) =>
-        v && v.toLowerCase() !== bg.toLowerCase() ? v : "";
-      const elev = distinct(c.inputBg) || mixHex(bg, fg, 0.06);
-      const rowHover = distinct(c.selectionBg) || mixHex(bg, fg, 0.1);
-      const selected = distinct(c.selectionBg) || mixHex(bg, accent, 0.22);
-      set("--bg", bg);
-      set("--bg-elev", elev);
-      set("--bg-row", bg);
-      set("--bg-row-hover", rowHover);
-      set("--bg-selected", selected);
-      set("--border", c.border || mixHex(bg, fg, 0.16));
-      set("--text", fg);
-      set("--text-muted", c.muted || mixHex(fg, bg, 0.4));
-      // Readable secondary text (keyboard hints, ghost buttons, loading) —
-      // always derived from fg/bg so it stays legible regardless of how faint a
-      // theme's own muted color is. t is the weight toward bg, so a smaller value
-      // than --text-muted's 0.4 keeps this closer to the text colour (higher
-      // contrast).
-      set("--text-dim", mixHex(fg, bg, 0.2));
-      set("--accent", accent);
-      set("--accent-strong", accent);
-      set("--danger", c.danger || "#ff6b6b");
-      set("--chip-bg", mixHex(bg, fg, 0.12));
-      set("--chip-text", fg);
-      set("--unread-dot", accent);
-      if (c.name) setCurrentTheme(c.name);
-    } catch {
-      /* non-fatal: keep the default palette */
-    }
-  }, []);
 
   const load = useCallback(async (q: string) => {
     setLoadingList(true);
@@ -721,16 +664,7 @@ export default function App() {
       } catch {
         /* non-fatal */
       }
-      try {
-        const on = await backend.ThemesEnabled();
-        setThemesOn(on);
-        if (on) {
-          setThemeNames(await backend.ListThemes());
-          await applyTheme(""); // apply the configured theme
-        }
-      } catch {
-        /* non-fatal */
-      }
+      await initTheme();
       try {
         setLabels(await backend.ListLabels());
       } catch {
@@ -751,7 +685,7 @@ export default function App() {
         /* non-fatal */
       }
       void load("");
-  }, [load, applyTheme]);
+  }, [load, initTheme]);
 
   useEffect(() => {
     void runInit();
@@ -2548,7 +2482,7 @@ export default function App() {
           break;
         case "zoom": {
           const n = Number(arg);
-          if (arg && n >= 0.6 && n <= 2.4) setUiZoom(n);
+          if (arg && n >= 0.6 && n <= 2.4) setZoom(n);
           else if (!arg) resetZoom();
           break;
         }
@@ -2740,6 +2674,7 @@ export default function App() {
       applyLabelChange,
       bumpZoom,
       resetZoom,
+      setZoom,
     ],
   );
 

--- a/desktop/frontend/src/useAttachments.ts
+++ b/desktop/frontend/src/useAttachments.ts
@@ -1,0 +1,60 @@
+import {
+  useCallback,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+import { backend, type Attachment, type MessageDetail } from "./api";
+
+// useAttachments owns the current message's attachment list, the picker's open
+// state, and downloading an attachment. Extracted from App.tsx unchanged (F3.2).
+// The list is still fetched inside loadMessage (gated by openIdRef) via
+// setAttachments; this hook owns the state and the download action.
+export interface Attachments {
+  attachments: Attachment[];
+  setAttachments: Dispatch<SetStateAction<Attachment[]>>;
+  attachmentsOpen: boolean;
+  setAttachmentsOpen: Dispatch<SetStateAction<boolean>>;
+  downloadAttachment: (att: Attachment) => Promise<void>;
+}
+
+export function useAttachments(
+  detail: MessageDetail | null,
+  deps: {
+    setBusy: (v: boolean) => void;
+    setError: (e: string) => void;
+    showToast: (m: string) => void;
+  },
+): Attachments {
+  const { setBusy, setError, showToast } = deps;
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const [attachmentsOpen, setAttachmentsOpen] = useState(false);
+
+  const downloadAttachment = useCallback(
+    async (att: Attachment) => {
+      if (!detail) return;
+      setBusy(true);
+      try {
+        const path = await backend.DownloadAttachment(
+          detail.id,
+          att.attachmentId,
+          att.filename,
+        );
+        showToast(`Saved to ${path}`);
+      } catch (e) {
+        setError(String(e));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [detail, setBusy, setError, showToast],
+  );
+
+  return {
+    attachments,
+    setAttachments,
+    attachmentsOpen,
+    setAttachmentsOpen,
+    downloadAttachment,
+  };
+}

--- a/desktop/frontend/src/useRsvp.ts
+++ b/desktop/frontend/src/useRsvp.ts
@@ -1,0 +1,77 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+} from "react";
+import { backend, type Invite } from "./api";
+
+// useRsvp owns the calendar-invite (RSVP) subsystem: whether RSVP is enabled,
+// the current message's invite, the in-flight response state, and the picker.
+// Extracted from App.tsx unchanged (F3.2). The per-message invite is still
+// fetched inside loadMessage (gated by openIdRef) via setInvite + the enabled
+// ref — this hook just owns the state and the respondInvite action.
+export interface Rsvp {
+  rsvpEnabled: boolean;
+  setRsvpEnabled: Dispatch<SetStateAction<boolean>>;
+  // Ref mirror so loadMessage (stable, no deps) can read the latest value.
+  rsvpEnabledRef: MutableRefObject<boolean>;
+  invite: Invite | null;
+  setInvite: Dispatch<SetStateAction<Invite | null>>;
+  rsvpBusy: string;
+  rsvpPickerOpen: boolean;
+  setRsvpPickerOpen: Dispatch<SetStateAction<boolean>>;
+  respondInvite: (
+    id: string,
+    status: "accepted" | "tentative" | "declined",
+  ) => Promise<void>;
+}
+
+export function useRsvp(deps: {
+  setError: (e: string) => void;
+  showToast: (m: string) => void;
+}): Rsvp {
+  const { setError, showToast } = deps;
+  const [rsvpEnabled, setRsvpEnabled] = useState(false);
+  const [invite, setInvite] = useState<Invite | null>(null);
+  const [rsvpBusy, setRsvpBusy] = useState("");
+  // The RSVP bar auto-shows for invites; V opens a keyboard-navigable picker.
+  const [rsvpPickerOpen, setRsvpPickerOpen] = useState(false);
+  const rsvpEnabledRef = useRef(false);
+  useEffect(() => {
+    rsvpEnabledRef.current = rsvpEnabled;
+  }, [rsvpEnabled]);
+
+  // respondInvite sends an RSVP (accepted/tentative/declined) for the open
+  // message's calendar invite.
+  const respondInvite = useCallback(
+    async (id: string, status: "accepted" | "tentative" | "declined") => {
+      setRsvpBusy(status);
+      setError("");
+      try {
+        await backend.RespondInvite(id, status);
+        showToast(`RSVP: ${status}`);
+      } catch (e) {
+        setError(String(e));
+      } finally {
+        setRsvpBusy("");
+      }
+    },
+    [setError, showToast],
+  );
+
+  return {
+    rsvpEnabled,
+    setRsvpEnabled,
+    rsvpEnabledRef,
+    invite,
+    setInvite,
+    rsvpBusy,
+    rsvpPickerOpen,
+    setRsvpPickerOpen,
+    respondInvite,
+  };
+}

--- a/desktop/frontend/src/useTheme.ts
+++ b/desktop/frontend/src/useTheme.ts
@@ -1,0 +1,100 @@
+import { useCallback, useState } from "react";
+import { backend } from "./api";
+import { mixHex } from "./format";
+
+// useTheme owns the desktop theme subsystem: whether theming is enabled, the
+// available theme names, the current one, the picker's open state, and applying
+// a theme's palette onto the CSS custom properties the stylesheet reads.
+// Extracted from App.tsx unchanged (F3.1) — no behavior change; applyTheme and
+// the startup init are the same logic, just moved behind a hook.
+export interface Theme {
+  themesOn: boolean;
+  themePickerOpen: boolean;
+  setThemePickerOpen: (v: boolean) => void;
+  themeNames: string[];
+  currentTheme: string;
+  // applyTheme fetches a theme's palette from the backend and maps it onto the
+  // CSS custom properties. Empty name = the configured (current) theme.
+  applyTheme: (name: string) => Promise<void>;
+  // initTheme resolves enablement + names and applies the configured theme;
+  // called once from the App's startup effect.
+  initTheme: () => Promise<void>;
+}
+
+export function useTheme(): Theme {
+  const [themesOn, setThemesOn] = useState(false);
+  const [themePickerOpen, setThemePickerOpen] = useState(false);
+  const [themeNames, setThemeNames] = useState<string[]>([]);
+  const [currentTheme, setCurrentTheme] = useState("");
+
+  const applyTheme = useCallback(async (name: string) => {
+    try {
+      const c = await backend.GetThemeColors(name);
+      if (!c) return;
+      const root = document.documentElement.style;
+      const set = (k: string, v: string) => {
+        if (v) root.setProperty(k, v);
+      };
+      // Map the theme palette onto the CSS custom properties the stylesheet
+      // reads. Elevated/hover surfaces are derived from the base background so
+      // the UI keeps its layering even when a theme only defines a few colors.
+      // The accent (focus color) — never the title color — drives buttons, so
+      // primary buttons stay in the theme's accent hue instead of turning into
+      // a loud title color (e.g. bright green).
+      const bg = c.bg || "#14161b";
+      const fg = c.fg || "#e6e8ec";
+      const accent = c.accent || "#6ea8fe";
+      const distinct = (v: string) =>
+        v && v.toLowerCase() !== bg.toLowerCase() ? v : "";
+      const elev = distinct(c.inputBg) || mixHex(bg, fg, 0.06);
+      const rowHover = distinct(c.selectionBg) || mixHex(bg, fg, 0.1);
+      const selected = distinct(c.selectionBg) || mixHex(bg, accent, 0.22);
+      set("--bg", bg);
+      set("--bg-elev", elev);
+      set("--bg-row", bg);
+      set("--bg-row-hover", rowHover);
+      set("--bg-selected", selected);
+      set("--border", c.border || mixHex(bg, fg, 0.16));
+      set("--text", fg);
+      set("--text-muted", c.muted || mixHex(fg, bg, 0.4));
+      // Readable secondary text (keyboard hints, ghost buttons, loading) —
+      // always derived from fg/bg so it stays legible regardless of how faint a
+      // theme's own muted color is. t is the weight toward bg, so a smaller value
+      // than --text-muted's 0.4 keeps this closer to the text colour (higher
+      // contrast).
+      set("--text-dim", mixHex(fg, bg, 0.2));
+      set("--accent", accent);
+      set("--accent-strong", accent);
+      set("--danger", c.danger || "#ff6b6b");
+      set("--chip-bg", mixHex(bg, fg, 0.12));
+      set("--chip-text", fg);
+      set("--unread-dot", accent);
+      if (c.name) setCurrentTheme(c.name);
+    } catch {
+      /* non-fatal: keep the default palette */
+    }
+  }, []);
+
+  const initTheme = useCallback(async () => {
+    try {
+      const on = await backend.ThemesEnabled();
+      setThemesOn(on);
+      if (on) {
+        setThemeNames(await backend.ListThemes());
+        await applyTheme(""); // apply the configured theme
+      }
+    } catch {
+      /* non-fatal */
+    }
+  }, [applyTheme]);
+
+  return {
+    themesOn,
+    themePickerOpen,
+    setThemePickerOpen,
+    themeNames,
+    currentTheme,
+    applyTheme,
+    initTheme,
+  };
+}

--- a/desktop/frontend/src/useThreading.ts
+++ b/desktop/frontend/src/useThreading.ts
@@ -1,0 +1,65 @@
+import {
+  useCallback,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+import { backend, type MessageDetail } from "./api";
+
+// useThreading owns the conversation-view subsystem: whether threading is
+// enabled, the loaded thread messages, which are collapsed, the loading flag,
+// and toggling the thread open/closed. Extracted from App.tsx unchanged (F3.2).
+//
+// NOTE: summarizeThread stays in App.tsx on purpose — it writes the AI summary
+// panel state (setSummarizing/setSummary), which belongs to the AI-panels
+// subsystem (F3.4), not here. This hook only owns the thread list itself.
+export interface Threading {
+  threadingOn: boolean;
+  setThreadingOn: Dispatch<SetStateAction<boolean>>;
+  threadMsgs: MessageDetail[] | null;
+  setThreadMsgs: Dispatch<SetStateAction<MessageDetail[] | null>>;
+  collapsedMsgs: Set<string>;
+  setCollapsedMsgs: Dispatch<SetStateAction<Set<string>>>;
+  loadingThread: boolean;
+  toggleThread: () => Promise<void>;
+}
+
+export function useThreading(
+  detail: MessageDetail | null,
+  deps: { setError: (e: string) => void },
+): Threading {
+  const { setError } = deps;
+  const [threadingOn, setThreadingOn] = useState(false);
+  const [threadMsgs, setThreadMsgs] = useState<MessageDetail[] | null>(null);
+  const [collapsedMsgs, setCollapsedMsgs] = useState<Set<string>>(new Set());
+  const [loadingThread, setLoadingThread] = useState(false);
+
+  const toggleThread = useCallback(async () => {
+    if (!detail) return;
+    if (threadMsgs) {
+      setThreadMsgs(null);
+      return;
+    }
+    setLoadingThread(true);
+    setError("");
+    try {
+      const msgs = await backend.GetThread(detail.threadId);
+      setThreadMsgs(msgs);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoadingThread(false);
+    }
+  }, [detail, threadMsgs, setError]);
+
+  return {
+    threadingOn,
+    setThreadingOn,
+    threadMsgs,
+    setThreadMsgs,
+    collapsedMsgs,
+    setCollapsedMsgs,
+    loadingThread,
+    toggleThread,
+  };
+}

--- a/desktop/frontend/src/useZoom.ts
+++ b/desktop/frontend/src/useZoom.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useState } from "react";
+
+// useZoom owns the UI zoom level. WKWebView doesn't honour Cmd/Ctrl +/-/0 to
+// scale the app, so we drive it ourselves via CSS `zoom` on the document root
+// and remember the choice in localStorage. Extracted from App.tsx unchanged
+// (F3.1) — behavior is identical: same clamp range, same rounding, same key.
+const MIN_ZOOM = 0.6;
+const MAX_ZOOM = 2.4;
+
+export interface Zoom {
+  // setZoom sets an absolute level. Callers validate the range (e.g. the ":zoom
+  // <n>" command), so this is the raw setter to keep behavior byte-identical.
+  setZoom: (n: number) => void;
+  // bumpZoom nudges the level by delta, clamped and rounded to one decimal.
+  bumpZoom: (delta: number) => void;
+  // resetZoom returns to 1.0.
+  resetZoom: () => void;
+}
+
+export function useZoom(): Zoom {
+  const [uiZoom, setUiZoom] = useState(() => {
+    const v = Number(localStorage.getItem("giztui.zoom"));
+    return v >= MIN_ZOOM && v <= MAX_ZOOM ? v : 1;
+  });
+  useEffect(() => {
+    (document.documentElement.style as unknown as { zoom: string }).zoom =
+      String(uiZoom);
+    localStorage.setItem("giztui.zoom", String(uiZoom));
+  }, [uiZoom]);
+  const bumpZoom = useCallback((delta: number) => {
+    setUiZoom((z) =>
+      Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, Math.round((z + delta) * 10) / 10)),
+    );
+  }, []);
+  const resetZoom = useCallback(() => setUiZoom(1), []);
+  return { setZoom: setUiZoom, bumpZoom, resetZoom };
+}

--- a/docs/DESKTOP_REFACTOR_PLAN.md
+++ b/docs/DESKTOP_REFACTOR_PLAN.md
@@ -17,9 +17,12 @@
 > the coupled flows (open→summarize, apply-prompt→switch→return, summary/prompt
 > per-message caching, search scope, picker open/arrow/Escape). **F3.1 is DONE
 > too — `useZoom` + `useTheme`** (safest hooks; guarded by `e2e/zoom.spec.ts` +
-> `e2e/theme.spec.ts`). **Next is F3.2 (`useThreading`, `useAttachments`,
-> `useRsvp`) → F3.3 (`useMessages`, touches `openIdRef`) → F3.4 (`useAiPanels`,
-> the 68-setter tangle) LAST.** For every hook extraction: keep `npm run test:e2e`
+> `e2e/theme.spec.ts`). **F3.2 is DONE too** — `useAttachments` + `useRsvp` +
+> `useThreading` extracted (per-message fetch/reset stays in `loadMessage`;
+> `summarizeThread` deferred to F3.4). **Next is F3.3 (`useMessages` —
+> list/load/pagination/pendingNew/prune; touches `openIdRef` and the load-bearing
+> reset order in `loadMessage`) → F3.4 (`useAiPanels`, the 68-setter tangle)
+> LAST.** For every hook extraction: keep `npm run test:e2e`
 > green (extend it when a hook adds a flow it doesn't yet cover) and re-read §3
 > (landmines) before touching any stateful code. The branch
 > `claude/giztui-visual-client-iadjgl` was reset off `main` after each merge —
@@ -165,7 +168,7 @@ Extract **as behavior-preserving moves**, safest → riskiest, Playwright in fro
 - [x] **F2** Command layer — `commands.ts` (COMMANDS + pure `parseCommand`/`filterCommands`/`resolveEnter`), CommandBar/App rewired, 9 unit tests + integrity check ✅. Scope kept safe: the big `executeCommand` switch stays as the handler adapter; **data-driven dispatch (actions object) is deferred** — low marginal value, higher risk.
 - [x] **F3.0** Playwright integration net — `@playwright/test` + `playwright.config.ts` (pre-installed Chromium, vite `webServer` on :5199) + `desktop/frontend/e2e/` (13 specs across inbox/reader, search scope, AI summary+prompt caching/landmines, pickers). `npm run test:e2e`. This is the safety net that guards every F3.x hook extraction ✅.
 - [x] **F3.1** `useZoom` (`src/useZoom.ts`) + `useTheme` (`src/useTheme.ts`) — behavior-preserving moves out of App.tsx (−65 net lines). No §3 landmines touched. Guarded by new e2e specs (`e2e/zoom.spec.ts`, `e2e/theme.spec.ts`; suite now 18 specs). Diff was a pure relocation (verified) ✅.
-- [ ] **F3.2** useThreading / useAttachments / useRsvp
+- [x] **F3.2** `useAttachments` + `useRsvp` + `useThreading` (`src/useAttachments.ts`, `src/useRsvp.ts`, `src/useThreading.ts`) — behavior-preserving moves. The per-message fetch/reset lines stay in `loadMessage` and call the hooks' setters/refs under the same names, so the reset ORDER + `openIdRef` gating are byte-identical. **`summarizeThread` deliberately stays in App.tsx** (it writes the AI-summary panel state → belongs to F3.4). Guarded by `e2e/attachments.spec.ts`, `e2e/rsvp.spec.ts`, `e2e/threading.spec.ts`; suite now 25 ✅.
 - [ ] **F3.3** useMessages
 - [ ] **F3.4** useAiPanels  ⚠️ highest risk
 - [ ] **F4** JSX component splits

--- a/docs/DESKTOP_REFACTOR_PLAN.md
+++ b/docs/DESKTOP_REFACTOR_PLAN.md
@@ -7,16 +7,21 @@
 > assistant's ephemeral context) so a fresh session, or a human, can pick it up
 > mid-flight. Update the **Progress tracker** as phases land.
 
-**Status:** F0–F2 DONE & merged (PR #61). Approach approved.
-**Owner:** _tbd_ · **Last updated:** 2026-07-25
+**Status:** F0–F2 DONE & merged (PR #61). Playwright integration net DONE (this batch). Approach approved.
+**Owner:** _tbd_ · **Last updated:** 2026-07-26
 
-> **▶ RESUME HERE (next session).** F0–F2 are merged: vitest harness + `format.ts`,
-> `compose.ts`, `commands.ts` extracted (38 unit tests; `npm test`). **Next is F3
-> (subsystem hooks) — but FIRST build the Playwright integration suite** (§5), the
-> only net for the coupled behavior; then extract hooks safest→riskiest with
-> `useAiPanels` LAST. Re-read §3 (landmines) before touching any stateful code.
-> The branch `claude/giztui-visual-client-iadjgl` was reset off `main` after each
-> merge — reset it to latest `main` again before starting.
+> **▶ RESUME HERE (next session).** F0–F2 are merged (vitest harness + `format.ts`,
+> `compose.ts`, `commands.ts`; 38 unit tests, `npm test`) **and the Playwright
+> integration net is now in place** (`desktop/frontend/e2e/`, 13 specs,
+> `npm run test:e2e`) — it drives the real app against the api.ts mock and covers
+> the coupled flows (open→summarize, apply-prompt→switch→return, summary/prompt
+> per-message caching, search scope, picker open/arrow/Escape). **Next is F3.1
+> (`useZoom` / `useTheme`) — the safest hooks — then F3.2 → F3.3 → F3.4 with
+> `useAiPanels` LAST.** For every hook extraction: keep `npm run test:e2e` green
+> (extend it when a hook adds a flow it doesn't yet cover) and re-read §3
+> (landmines) before touching any stateful code. The branch
+> `claude/giztui-visual-client-iadjgl` was reset off `main` after each merge —
+> reset it to latest `main` again before starting.
 
 > **Sequencing note (refinement, approved):** Playwright integration tests protect
 > the *coupled* refactors (F3). F1/F2 are pure/near-pure and are protected by unit
@@ -156,6 +161,7 @@ Extract **as behavior-preserving moves**, safest → riskiest, Playwright in fro
 - [x] **F0** Harness — vitest + jsdom, `test` script (Playwright suite deferred to F3 start)
 - [x] **F1** Pure helpers + unit tests — `format.ts` (11 fns, 23 tests) + `compose.ts` (reply/replyAll/forward, 6 tests) ✅
 - [x] **F2** Command layer — `commands.ts` (COMMANDS + pure `parseCommand`/`filterCommands`/`resolveEnter`), CommandBar/App rewired, 9 unit tests + integrity check ✅. Scope kept safe: the big `executeCommand` switch stays as the handler adapter; **data-driven dispatch (actions object) is deferred** — low marginal value, higher risk.
+- [x] **F3.0** Playwright integration net — `@playwright/test` + `playwright.config.ts` (pre-installed Chromium, vite `webServer` on :5199) + `desktop/frontend/e2e/` (13 specs across inbox/reader, search scope, AI summary+prompt caching/landmines, pickers). `npm run test:e2e`. This is the safety net that guards every F3.x hook extraction ✅.
 - [ ] **F3.1** useZoom / useTheme
 - [ ] **F3.2** useThreading / useAttachments / useRsvp
 - [ ] **F3.3** useMessages
@@ -174,8 +180,12 @@ Extract **as behavior-preserving moves**, safest → riskiest, Playwright in fro
 
 - [x] vitest + jsdom approved as the unit harness.
 - [x] Order approved: F0 → F1 → F2 this batch; F3 (hooks) in dedicated sessions.
-- [ ] Where do Playwright specs live (`desktop/frontend/e2e/`?) and do we wire them
-  into CI or keep them local-run for now? (decide at F3 start)
+- [x] Playwright specs live in **`desktop/frontend/e2e/`**, run via **`npm run test:e2e`**
+  (config `desktop/frontend/playwright.config.ts`; a vite `webServer` boots the app
+  against the api.ts mock; Chromium is the pre-installed browser, never downloaded).
+  Kept **local-run for now** (not wired into CI) — revisit wiring it into CI once the
+  F3 hook extractions have proven the suite stays stable. Artifacts
+  (`test-results/`, `playwright-report/`) are git-ignored.
 
 ## 10. Related outstanding work (NOT this plan — separate backlog)
 

--- a/docs/DESKTOP_REFACTOR_PLAN.md
+++ b/docs/DESKTOP_REFACTOR_PLAN.md
@@ -15,10 +15,12 @@
 > integration net is now in place** (`desktop/frontend/e2e/`, 13 specs,
 > `npm run test:e2e`) — it drives the real app against the api.ts mock and covers
 > the coupled flows (open→summarize, apply-prompt→switch→return, summary/prompt
-> per-message caching, search scope, picker open/arrow/Escape). **Next is F3.1
-> (`useZoom` / `useTheme`) — the safest hooks — then F3.2 → F3.3 → F3.4 with
-> `useAiPanels` LAST.** For every hook extraction: keep `npm run test:e2e` green
-> (extend it when a hook adds a flow it doesn't yet cover) and re-read §3
+> per-message caching, search scope, picker open/arrow/Escape). **F3.1 is DONE
+> too — `useZoom` + `useTheme`** (safest hooks; guarded by `e2e/zoom.spec.ts` +
+> `e2e/theme.spec.ts`). **Next is F3.2 (`useThreading`, `useAttachments`,
+> `useRsvp`) → F3.3 (`useMessages`, touches `openIdRef`) → F3.4 (`useAiPanels`,
+> the 68-setter tangle) LAST.** For every hook extraction: keep `npm run test:e2e`
+> green (extend it when a hook adds a flow it doesn't yet cover) and re-read §3
 > (landmines) before touching any stateful code. The branch
 > `claude/giztui-visual-client-iadjgl` was reset off `main` after each merge —
 > reset it to latest `main` again before starting.
@@ -162,7 +164,7 @@ Extract **as behavior-preserving moves**, safest → riskiest, Playwright in fro
 - [x] **F1** Pure helpers + unit tests — `format.ts` (11 fns, 23 tests) + `compose.ts` (reply/replyAll/forward, 6 tests) ✅
 - [x] **F2** Command layer — `commands.ts` (COMMANDS + pure `parseCommand`/`filterCommands`/`resolveEnter`), CommandBar/App rewired, 9 unit tests + integrity check ✅. Scope kept safe: the big `executeCommand` switch stays as the handler adapter; **data-driven dispatch (actions object) is deferred** — low marginal value, higher risk.
 - [x] **F3.0** Playwright integration net — `@playwright/test` + `playwright.config.ts` (pre-installed Chromium, vite `webServer` on :5199) + `desktop/frontend/e2e/` (13 specs across inbox/reader, search scope, AI summary+prompt caching/landmines, pickers). `npm run test:e2e`. This is the safety net that guards every F3.x hook extraction ✅.
-- [ ] **F3.1** useZoom / useTheme
+- [x] **F3.1** `useZoom` (`src/useZoom.ts`) + `useTheme` (`src/useTheme.ts`) — behavior-preserving moves out of App.tsx (−65 net lines). No §3 landmines touched. Guarded by new e2e specs (`e2e/zoom.spec.ts`, `e2e/theme.spec.ts`; suite now 18 specs). Diff was a pure relocation (verified) ✅.
 - [ ] **F3.2** useThreading / useAttachments / useRsvp
 - [ ] **F3.3** useMessages
 - [ ] **F3.4** useAiPanels  ⚠️ highest risk


### PR DESCRIPTION
## 📋 Description

Second refactor batch from `docs/DESKTOP_REFACTOR_PLAN.md`: stand up the **Playwright integration net** (the only safety net for `App.tsx`'s coupled behavior) and extract the **lower-risk subsystem hooks** under its protection. **Zero behavior change.**

- **F3.0 — Integration net:** `@playwright/test` + `playwright.config.ts` (pre-installed Chromium, vite `webServer` on :5199) + `desktop/frontend/e2e/` with specs across inbox/reader, search scoping, **AI summary+prompt caching/landmines**, and pickers. `npm run test:e2e`.
- **F3.1 — `useZoom` + `useTheme`** (pure relocations; −65 net lines).
- **F3.2 — `useAttachments` + `useRsvp` + `useThreading`.** The per-message fetch/reset lines **stay in `loadMessage`** and call the hooks' setters/refs under the same names, so the reset **order** + `openIdRef` gating are byte-identical. `summarizeThread` deliberately stays in App.tsx (it writes AI-panel state → belongs to F3.4).

`App.tsx`: **5,747 → 5,409** lines. Hooks: `useZoom`, `useTheme`, `useAttachments`, `useRsvp`, `useThreading`.

## 🧪 Testing
- [x] `npm test` — 38 unit tests passing
- [x] `npm run test:e2e` — **25 Playwright specs passing** (incl. per-message AI caching, dismiss, prompt-survives-switch — the §3 landmines)
- [x] `npx tsc --noEmit` + `npm run build` clean
- [x] Each hook extraction was a behavior-preserving move, guarded by new e2e specs

## 📝 Related
Executes F3.0–F3.2 of `docs/DESKTOP_REFACTOR_PLAN.md`. **Deliberately stops before F3.3 (`useMessages`) and F3.4 (`useAiPanels`)** — the highest-risk extractions (loadMessage/openIdRef ordering; the 68-setter AI tangle), to be done in a dedicated pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU)_