### PR TITLE
refactor(desktop): extract pure inbox list logic to messageList.ts (F3.3)

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -49,6 +49,7 @@ import {
   formatSize,
 } from "./format";
 import { replyInit, replyAllInit, forwardInit } from "./compose";
+import { freshPrefix, dedupeNew } from "./messageList";
 import {
   buildMoveTargets,
   applyPlanMove,
@@ -556,20 +557,12 @@ export default function App() {
       const list = await backend.ListInbox("", PAGE_SIZE);
       const msgs = list.messages ?? [];
       const known = new Set(fullMessagesRef.current.map((m) => m.id));
-      // New mail always arrives at the TOP of the inbox, so it's the contiguous
-      // prefix of page 1 before the first message we already have. Stop at the
-      // first known id: older messages that shifted onto page 1 after a delete
-      // are NOT new — filtering by "unknown" alone would prepend those older
-      // messages to the top and scramble the order.
-      const fresh: MessageSummary[] = [];
-      for (const m of msgs) {
-        if (known.has(m.id)) break;
-        fresh.push(m);
-      }
-      // Hold new mail in a banner instead of prepending it — injecting rows at
-      // the top while the user is reading/selecting shifts everything under them
-      // and they can end up acting on a different message than they see.
-      setPendingNew(fresh);
+      // freshPrefix = the contiguous run of unknown messages at the top (new mail
+      // lands there); stopping at the first known id avoids treating messages that
+      // shifted onto page 1 after a delete as new (which would scramble order).
+      // Hold it in a banner instead of prepending — injecting rows while the user
+      // reads/selects shifts everything under them and they act on the wrong one.
+      setPendingNew(freshPrefix(msgs, known));
     } catch {
       /* transient; try again next tick */
     }
@@ -581,7 +574,7 @@ export default function App() {
     setPendingNew((pending) => {
       if (pending.length === 0) return pending;
       const known = new Set(fullMessagesRef.current.map((m) => m.id));
-      const toAdd = pending.filter((m) => !known.has(m.id));
+      const toAdd = dedupeNew(pending, known);
       if (toAdd.length > 0) {
         fullMessagesRef.current = [...toAdd, ...fullMessagesRef.current];
         setMessages((prev) => [...toAdd, ...prev]);

--- a/desktop/frontend/src/messageList.test.ts
+++ b/desktop/frontend/src/messageList.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { freshPrefix, dedupeNew } from "./messageList";
+
+const m = (id: string) => ({ id });
+
+describe("freshPrefix", () => {
+  it("returns all messages when none are known", () => {
+    expect(freshPrefix([m("a"), m("b")], new Set())).toEqual([m("a"), m("b")]);
+  });
+  it("returns nothing when the first message is already known", () => {
+    expect(freshPrefix([m("a"), m("b")], new Set(["a"]))).toEqual([]);
+  });
+  it("returns only the contiguous unknown prefix, stopping at the first known id", () => {
+    expect(freshPrefix([m("n1"), m("n2"), m("k1")], new Set(["k1"]))).toEqual([
+      m("n1"),
+      m("n2"),
+    ]);
+  });
+  it("does NOT treat a later unknown id past a known one as new (the scramble guard)", () => {
+    // 'old' shifted onto page 1 after a delete: unknown to us, but it appears
+    // AFTER a known message, so it must not be prepended as new mail.
+    const page = [m("new1"), m("known"), m("old")];
+    expect(freshPrefix(page, new Set(["known"]))).toEqual([m("new1")]);
+  });
+  it("handles an empty page", () => {
+    expect(freshPrefix([], new Set(["a"]))).toEqual([]);
+  });
+});
+
+describe("dedupeNew", () => {
+  it("drops items already known", () => {
+    expect(dedupeNew([m("a"), m("b"), m("c")], new Set(["b"]))).toEqual([m("a"), m("c")]);
+  });
+  it("keeps everything when nothing is known", () => {
+    expect(dedupeNew([m("a")], new Set())).toEqual([m("a")]);
+  });
+  it("returns empty when all are known", () => {
+    expect(dedupeNew([m("a"), m("b")], new Set(["a", "b"]))).toEqual([]);
+  });
+});

--- a/desktop/frontend/src/messageList.ts
+++ b/desktop/frontend/src/messageList.ts
@@ -1,0 +1,30 @@
+// Pure list logic for the inbox, extracted from App.tsx so the new-mail
+// detection (the exact logic behind the "inbox scramble after deletes" bug) is
+// unit-tested in isolation. No React, no state.
+
+// freshPrefix returns the contiguous run of *unknown* messages at the FRONT of a
+// freshly fetched inbox page. New mail always arrives at the top, so it is the
+// prefix of page 1 before the first message we already have. Stopping at the
+// first known id matters: after a delete, older messages shift onto page 1;
+// they are unknown-to-us but NOT new, and filtering by "unknown" alone would
+// prepend them to the top and scramble the order.
+export function freshPrefix<T extends { id: string }>(
+  fetched: T[],
+  knownIds: Set<string>,
+): T[] {
+  const fresh: T[] = [];
+  for (const m of fetched) {
+    if (knownIds.has(m.id)) break;
+    fresh.push(m);
+  }
+  return fresh;
+}
+
+// dedupeNew drops items whose id is already known — a manual refresh may have
+// pulled some of the pending (banner-held) mail in before it was shown.
+export function dedupeNew<T extends { id: string }>(
+  pending: T[],
+  knownIds: Set<string>,
+): T[] {
+  return pending.filter((m) => !knownIds.has(m.id));
+}

--- a/docs/DESKTOP_REFACTOR_PLAN.md
+++ b/docs/DESKTOP_REFACTOR_PLAN.md
@@ -169,7 +169,15 @@ Extract **as behavior-preserving moves**, safest → riskiest, Playwright in fro
 - [x] **F3.0** Playwright integration net — `@playwright/test` + `playwright.config.ts` (pre-installed Chromium, vite `webServer` on :5199) + `desktop/frontend/e2e/` (13 specs across inbox/reader, search scope, AI summary+prompt caching/landmines, pickers). `npm run test:e2e`. This is the safety net that guards every F3.x hook extraction ✅.
 - [x] **F3.1** `useZoom` (`src/useZoom.ts`) + `useTheme` (`src/useTheme.ts`) — behavior-preserving moves out of App.tsx (−65 net lines). No §3 landmines touched. Guarded by new e2e specs (`e2e/zoom.spec.ts`, `e2e/theme.spec.ts`; suite now 18 specs). Diff was a pure relocation (verified) ✅.
 - [x] **F3.2** `useAttachments` + `useRsvp` + `useThreading` (`src/useAttachments.ts`, `src/useRsvp.ts`, `src/useThreading.ts`) — behavior-preserving moves. The per-message fetch/reset lines stay in `loadMessage` and call the hooks' setters/refs under the same names, so the reset ORDER + `openIdRef` gating are byte-identical. **`summarizeThread` deliberately stays in App.tsx** (it writes the AI-summary panel state → belongs to F3.4). Guarded by `e2e/attachments.spec.ts`, `e2e/rsvp.spec.ts`, `e2e/threading.spec.ts`; suite now 25 ✅.
-- [ ] **F3.3** useMessages
+- [x] **F3.3** Message-list logic — scoped safely: the list *state* (`messages`/
+  `fullMessagesRef`) is a cross-cutting spine used by ~20 call sites (every
+  bulk/doAction/prune), and `loadMessage` reaches into AI restore (F3.4 territory),
+  so a full `useMessages` hook would be high-churn prop-threading with little real
+  decoupling. Instead extracted the **pure list logic** to `messageList.ts`
+  (`freshPrefix` = contiguous-unknown-prefix new-mail detection — the anti-scramble
+  logic; `dedupeNew`) + 8 unit tests including the "old message shifted onto page 1
+  after a delete is NOT new" case. No React state moved; no §3 landmines touched.
+  Guarded by the e2e inbox specs ✅.
 - [ ] **F3.4** useAiPanels  ⚠️ highest risk
 - [ ] **F4** JSX component splits
 


### PR DESCRIPTION
## 📋 Description

F3.3 of `docs/DESKTOP_REFACTOR_PLAN.md`, **scoped conservatively for safety**.

A full `useMessages` hook was assessed and **deliberately not done**: the list state (`messages` / `fullMessagesRef`) is a cross-cutting spine used by ~20 call sites (every bulk op / doAction / prune), and `loadMessage` reaches into AI-panel restore (F3.4 territory). Moving it into a hook would be high-churn prop-threading with little real decoupling and more surface for subtle mistakes.

Instead, extract the **pure list logic** into `messageList.ts`:
- `freshPrefix` — the contiguous-unknown-prefix new-mail detection (**the anti-scramble guard**: an old message that shifts onto page 1 after a delete is unknown-to-us but must not be treated as new).
- `dedupeNew` — drop already-known ids when merging held new mail.

Covered by 8 unit tests, including the scramble case. **No React state moved, no §3 landmines touched.**

## 🧪 Testing
- [x] `npm test` — 46 unit tests (was 38; +8 for messageList)
- [x] `npm run test:e2e` — 25 Playwright specs green (inbox specs guard the new-mail behavior)
- [x] `tsc --noEmit` + `npm run build` clean
- [x] Behavior-identical (App.tsx now calls the extracted pures)

## 📝 Related
F3.3 done. **Stops before F3.4 (`useAiPanels`)** — the highest-risk extraction (the 68-setter AI tangle), to be tackled in a dedicated pass with the e2e AI specs in front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU)_