### PR TITLE
refactor(desktop): extract pure AI regenerate-decision to aiPanels.ts (F3.4)

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -50,6 +50,7 @@ import {
 } from "./format";
 import { replyInit, replyAllInit, forwardInit } from "./compose";
 import { freshPrefix, dedupeNew } from "./messageList";
+import { activeAiPanel } from "./aiPanels";
 import {
   buildMoveTargets,
   applyPlanMove,
@@ -1615,8 +1616,12 @@ export default function App() {
   const regenerateActive = useCallback(() => {
     const id = openIdRef.current;
     if (!id) return;
-    // A prompt is the active AI output (and no summary up) → regenerate the prompt.
-    if (promptResultRef.current !== null && summaryRef.current === null) {
+    const kind = activeAiPanel({
+      hasSummary: summaryRef.current !== null,
+      hasPrompt: promptResultRef.current !== null,
+      hasTouchUp: touchUpTextRef.current !== null,
+    });
+    if (kind === "prompt") {
       const pid = aiCache.current.get(id)?.lastPromptId;
       if (pid != null)
         void runPrompt(
@@ -1625,16 +1630,11 @@ export default function App() {
         );
       return;
     }
-    // A reformat (touch-up) is the active output → re-reformat, not summarize.
-    if (
-      touchUpTextRef.current !== null &&
-      summaryRef.current === null &&
-      promptResultRef.current === null
-    ) {
+    if (kind === "touchup") {
       void touchUp(id);
       return;
     }
-    // Otherwise (a summary is shown, or nothing yet) → (re)generate the summary.
+    // summary is shown, or nothing yet → (re)generate the summary.
     if (aiEnabled) void summarize(id, true);
   }, [summarize, runPrompt, touchUp, aiEnabled]);
 

--- a/desktop/frontend/src/aiPanels.test.ts
+++ b/desktop/frontend/src/aiPanels.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { activeAiPanel } from "./aiPanels";
+
+const s = (o: Partial<{ hasSummary: boolean; hasPrompt: boolean; hasTouchUp: boolean }>) => ({
+  hasSummary: false,
+  hasPrompt: false,
+  hasTouchUp: false,
+  ...o,
+});
+
+describe("activeAiPanel", () => {
+  it("regenerates the prompt when a prompt result is up and no summary", () => {
+    expect(activeAiPanel(s({ hasPrompt: true }))).toBe("prompt");
+  });
+  it("prefers the summary when both a summary and a prompt are shown", () => {
+    expect(activeAiPanel(s({ hasSummary: true, hasPrompt: true }))).toBe("summary");
+  });
+  it("re-reformats when only a touch-up is shown", () => {
+    expect(activeAiPanel(s({ hasTouchUp: true }))).toBe("touchup");
+  });
+  it("does NOT pick touch-up if a prompt or summary is also up", () => {
+    expect(activeAiPanel(s({ hasTouchUp: true, hasPrompt: true }))).toBe("prompt");
+    expect(activeAiPanel(s({ hasTouchUp: true, hasSummary: true }))).toBe("summary");
+  });
+  it("defaults to summary when a summary is shown or nothing is", () => {
+    expect(activeAiPanel(s({ hasSummary: true }))).toBe("summary");
+    expect(activeAiPanel(s({}))).toBe("summary");
+  });
+});

--- a/desktop/frontend/src/aiPanels.ts
+++ b/desktop/frontend/src/aiPanels.ts
@@ -1,0 +1,23 @@
+// Pure decision logic for the AI panels, extracted from App.tsx. The stateful
+// streaming (summarize/runPrompt/touchUp) and their refs stay in App by design:
+// they're coupled to the shared openIdRef and to loadMessage's reset ordering
+// (see docs/DESKTOP_REFACTOR_PLAN.md §3). What IS cleanly separable is the
+// branching that decides which panel is "active" — the bit that's easy to get
+// subtly wrong — so it lives here with tests.
+
+export type AiPanelKind = "summary" | "prompt" | "touchup";
+
+// activeAiPanel picks which panel a "regenerate" should re-run, given which
+// panels currently hold content. Mirrors App's original order exactly:
+//   - a prompt result (and no summary) → regenerate the prompt
+//   - else a touch-up (and nothing else) → re-reformat
+//   - else (a summary is shown, or nothing yet) → (re)generate the summary
+export function activeAiPanel(s: {
+  hasSummary: boolean;
+  hasPrompt: boolean;
+  hasTouchUp: boolean;
+}): AiPanelKind {
+  if (s.hasPrompt && !s.hasSummary) return "prompt";
+  if (s.hasTouchUp && !s.hasSummary && !s.hasPrompt) return "touchup";
+  return "summary";
+}

--- a/docs/DESKTOP_REFACTOR_PLAN.md
+++ b/docs/DESKTOP_REFACTOR_PLAN.md
@@ -178,7 +178,16 @@ Extract **as behavior-preserving moves**, safest → riskiest, Playwright in fro
   logic; `dedupeNew`) + 8 unit tests including the "old message shifted onto page 1
   after a delete is NOT new" case. No React state moved; no §3 landmines touched.
   Guarded by the e2e inbox specs ✅.
-- [ ] **F3.4** useAiPanels  ⚠️ highest risk
+- [x] **F3.4** AI panels — scoped to the safe slice, full state-relocation **assessed & declined**.
+  A `useAiPanels` state hook is high-risk / low-reward here: `openIdRef` is shared
+  (attachments/invite/loader/AI), so it can't be AI-owned; `loadMessage`'s AI-restore
+  is interleaved with the reset ORDER (a §3 landmine), so a hook would relocate the
+  coupling, not remove it; and the render is already extracted (`AiPanel`). Instead
+  extracted the **pure regenerate-decision** (`activeAiPanel` in `src/aiPanels.ts`) —
+  the branching that's easy to get subtly wrong — with 5 unit tests. Stateful
+  streaming (summarize/runPrompt/touchUp) + refs stay in App **by design**. Guarded
+  by the e2e AI specs ✅. _If a full relocation is still wanted, it's a dedicated,
+  high-care pass — but the ROI is line-moving, not decoupling._
 - [ ] **F4** JSX component splits
 
 ## 8. Safety rules (non-negotiable)


### PR DESCRIPTION
## 📋 Description

F3.4 of the plan — the highest-risk area. **A full `useAiPanels` state hook was assessed and deliberately NOT done**, for concrete reasons:

1. `openIdRef` is **shared** across attachments / invite / the message loader / AI — it can't be AI-owned, so a hook wouldn't encapsulate cleanly.
2. `loadMessage`'s AI-restore is interleaved with the reset **order** (a §3 landmine we fixed this session). Moving `aiCache` + setters into a hook makes `loadMessage` call back into it — the coupling is relocated, not removed.
3. The **render is already extracted** (`AiPanel`). Moving the state would be line-relocation, not decoupling, in the exact area where every bug this session lived.

Instead, extracted the one cleanly-separable, bug-prone piece: the **regenerate "which panel is active" branching** → pure `activeAiPanel()` in `src/aiPanels.ts`, with 5 unit tests covering the precedence (prompt > touch-up, summary wins, default summary). Stateful streaming (`summarize`/`runPrompt`/`touchUp`) + refs stay in App **by design**.

## 🧪 Testing
- [x] `npm test` — 51 unit tests (was 46; +5 for aiPanels)
- [x] `npm run test:e2e` — 25 Playwright specs green (the AI specs guard summarize/prompt/regenerate/dismiss)
- [x] `tsc --noEmit` + `npm run build` clean
- [x] Behavior-identical (`regenerateActive` now delegates the decision to the pure fn)

## 📝 Related
Closes the F3 hook phase. Remaining plan item: **F4** (JSX component splits — mechanical). A full AI state-relocation remains available as a dedicated high-care pass if desired, but its ROI is line-moving, not decoupling (see plan doc F3.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU)_