### PR TITLE
refactor(desktop): extract Stats/Config/PromptPreview modals from App.tsx (F4.1–F4.2)

### DIFF
--- a/desktop/frontend/e2e/modals.spec.ts
+++ b/desktop/frontend/e2e/modals.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test";
+import { openApp, runCommand } from "./helpers";
+
+// Display modals extracted from App.tsx (StatsModal / ConfigModal) — verify they
+// still open via their command and close on Escape after the F4 extraction.
+test.describe("display modals", () => {
+  test("':stats' opens the AI usage modal and Escape closes it", async ({ page }) => {
+    await openApp(page);
+    await runCommand(page, "stats");
+    const modal = page.locator(".modal-overlay").filter({ hasText: "AI usage" });
+    await expect(modal).toBeVisible();
+    await expect(modal.locator(".stat-tile").first()).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(modal).toBeHidden();
+  });
+
+  test("':config' opens the configuration modal and Escape closes it", async ({ page }) => {
+    await openApp(page);
+    await runCommand(page, "config");
+    const modal = page.locator(".modal-overlay").filter({ hasText: "Configuration" });
+    await expect(modal).toBeVisible();
+    await expect(modal.locator(".config-row").first()).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(modal).toBeHidden();
+  });
+});

--- a/desktop/frontend/e2e/modals.spec.ts
+++ b/desktop/frontend/e2e/modals.spec.ts
@@ -23,4 +23,14 @@ test.describe("display modals", () => {
     await page.keyboard.press("Escape");
     await expect(modal).toBeHidden();
   });
+
+  test("':action-plan prompt' opens the analyzer-prompt preview; Escape closes it", async ({ page }) => {
+    await openApp(page);
+    await runCommand(page, "action-plan prompt");
+    const modal = page.locator(".modal-overlay").filter({ hasText: "Analyzer prompt" });
+    await expect(modal).toBeVisible();
+    await expect(modal.locator("pre.summary-text")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(modal).toBeHidden();
+  });
 });

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -51,6 +51,8 @@ import {
 import { replyInit, replyAllInit, forwardInit } from "./compose";
 import { freshPrefix, dedupeNew } from "./messageList";
 import { activeAiPanel } from "./aiPanels";
+import StatsModal from "./StatsModal";
+import ConfigModal from "./ConfigModal";
 import {
   buildMoveTargets,
   applyPlanMove,
@@ -5268,112 +5270,14 @@ export default function App() {
         </div>
       )}
       {statsOpen && (
-        <div className="modal-overlay" onClick={() => setStatsOpen(false)}>
-          <div
-            className="modal narrow"
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => {
-              if (e.key === "Escape") setStatsOpen(false);
-            }}
-          >
-            <div className="modal-head">
-              <h3>AI usage</h3>
-              <button className="ghost" onClick={() => setStatsOpen(false)}>
-                ✕
-              </button>
-            </div>
-            <div className="modal-body">
-              {!stats ? (
-                <div className="placeholder">Loading…</div>
-              ) : (
-                <>
-                  <div className="stats-summary">
-                    <div className="stat-tile">
-                      <span className="stat-num">{stats.totalUsage}</span>
-                      <span className="stat-label muted">total runs</span>
-                    </div>
-                    <div className="stat-tile">
-                      <span className="stat-num">{stats.uniquePrompts}</span>
-                      <span className="stat-label muted">prompts used</span>
-                    </div>
-                  </div>
-                  <div className="label-list">
-                    {stats.topPrompts.length === 0 ? (
-                      <div className="placeholder">No usage yet</div>
-                    ) : (
-                      stats.topPrompts.map((p) => (
-                        <div key={p.name} className="stat-row">
-                          <span className="stat-row-name">{p.name}</span>
-                          {p.category && (
-                            <span className="stat-row-cat muted">
-                              {p.category}
-                            </span>
-                          )}
-                          <span className="stat-row-count">{p.usageCount}</span>
-                        </div>
-                      ))
-                    )}
-                  </div>
-                </>
-              )}
-            </div>
-          </div>
-        </div>
+        <StatsModal stats={stats} onClose={() => setStatsOpen(false)} />
       )}
       {configOpen && (
-        <div className="modal-overlay" onClick={() => setConfigOpen(false)}>
-          <div
-            className="modal narrow"
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => {
-              if (e.key === "Escape") setConfigOpen(false);
-            }}
-          >
-            <div className="modal-head">
-              <h3>Configuration</h3>
-              <button className="ghost" onClick={() => setConfigOpen(false)}>
-                ✕
-              </button>
-            </div>
-            <div className="modal-body">
-              {!configInfo ? (
-                <div className="placeholder">Loading…</div>
-              ) : (
-                <div className="config-list">
-                  {(
-                    [
-                      ["Account", configInfo.account],
-                      ["Config file", configInfo.configPath],
-                      ["Log file", configInfo.logPath],
-                      [
-                        "LLM",
-                        configInfo.llmModel
-                          ? `${configInfo.llmProvider} · ${configInfo.llmModel}`
-                          : "disabled",
-                      ],
-                      ["Theme", configInfo.theme || "default"],
-                      ["Downloads", configInfo.downloadPath],
-                      ["Obsidian", configInfo.obsidianOn ? "on" : "off"],
-                      ["Slack", configInfo.slackOn ? "on" : "off"],
-                      ["Auto-refresh", configInfo.autoRefresh ? "on" : "off"],
-                    ] as [string, string][]
-                  ).map(([k, v]) => (
-                    <div key={k} className="config-row">
-                      <span className="config-key muted">{k}</span>
-                      <span className="config-val">{v}</span>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-            <div className="modal-foot">
-              <button className="ghost" onClick={() => void clearCaches()}>
-                Clear AI caches
-              </button>
-              <button onClick={() => setConfigOpen(false)}>Close</button>
-            </div>
-          </div>
-        </div>
+        <ConfigModal
+          info={configInfo}
+          onClearCaches={() => void clearCaches()}
+          onClose={() => setConfigOpen(false)}
+        />
       )}
       {showHelp && (
         <Help

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -53,6 +53,7 @@ import { freshPrefix, dedupeNew } from "./messageList";
 import { activeAiPanel } from "./aiPanels";
 import StatsModal from "./StatsModal";
 import ConfigModal from "./ConfigModal";
+import PromptPreviewModal from "./PromptPreviewModal";
 import {
   buildMoveTargets,
   applyPlanMove,
@@ -255,7 +256,6 @@ export default function App() {
   const [rules, setRules] = useState<AnalyzerRule[]>([]);
   const [newRule, setNewRule] = useState("");
   const [promptPreview, setPromptPreview] = useState<string | null>(null);
-  const promptPreviewBodyRef = useRef<HTMLDivElement>(null);
   // Theme subsystem (enablement, names, current, picker, applyTheme) lives in useTheme.
   const {
     themesOn,
@@ -2134,34 +2134,6 @@ export default function App() {
       setError(String(e));
     }
   }, []);
-
-  // The analyzer-prompt preview is a long scrollable <pre>, but WKWebView won't
-  // focus the bare modal body so arrows/PageUp/etc. never reach it. While the
-  // preview is open, drive its scrolling from a window-level listener (Escape is
-  // handled by the global modal chain).
-  useEffect(() => {
-    if (promptPreview === null) return;
-    const h = (e: KeyboardEvent) => {
-      const el = promptPreviewBodyRef.current;
-      if (!el) return;
-      const line = 48;
-      const page = el.clientHeight * 0.9;
-      let dy = 0;
-      switch (e.key) {
-        case "ArrowDown": case "j": dy = line; break;
-        case "ArrowUp": case "k": dy = -line; break;
-        case "PageDown": case " ": dy = page; break;
-        case "PageUp": dy = -page; break;
-        case "Home": el.scrollTo({ top: 0 }); e.preventDefault(); return;
-        case "End": el.scrollTo({ top: el.scrollHeight }); e.preventDefault(); return;
-        default: return;
-      }
-      el.scrollBy({ top: dy });
-      e.preventDefault();
-    };
-    window.addEventListener("keydown", h, true);
-    return () => window.removeEventListener("keydown", h, true);
-  }, [promptPreview]);
 
   // Command palette dispatcher (`:` command mode).
   const executeCommand = useCallback(
@@ -5108,23 +5080,10 @@ export default function App() {
         </div>
       )}
       {promptPreview !== null && (
-        <div className="modal-overlay" onClick={() => setPromptPreview(null)}>
-          <div className="modal" onClick={(e) => e.stopPropagation()}>
-            <div className="modal-head">
-              <h3>Analyzer prompt</h3>
-              <button className="ghost" onClick={() => setPromptPreview(null)}>
-                ✕
-              </button>
-            </div>
-            <div className="modal-body" ref={promptPreviewBodyRef}>
-              <pre className="summary-text">{promptPreview}</pre>
-            </div>
-            <div className="modal-foot">
-              <span className="foot-hint">↑↓ scroll · Esc close</span>
-              <button onClick={() => setPromptPreview(null)}>Close</button>
-            </div>
-          </div>
-        </div>
+        <PromptPreviewModal
+          text={promptPreview}
+          onClose={() => setPromptPreview(null)}
+        />
       )}
       {cmdOpen && (
         <CommandBar

--- a/desktop/frontend/src/ConfigModal.tsx
+++ b/desktop/frontend/src/ConfigModal.tsx
@@ -1,0 +1,69 @@
+import type { ConfigInfo } from "./api";
+
+// Read-only configuration summary (opened by :config). Pure display modal; the
+// only action is "Clear AI caches", delegated to the parent.
+export default function ConfigModal({
+  info,
+  onClearCaches,
+  onClose,
+}: {
+  info: ConfigInfo | null;
+  onClearCaches: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="modal narrow"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") onClose();
+        }}
+      >
+        <div className="modal-head">
+          <h3>Configuration</h3>
+          <button className="ghost" onClick={onClose}>
+            ✕
+          </button>
+        </div>
+        <div className="modal-body">
+          {!info ? (
+            <div className="placeholder">Loading…</div>
+          ) : (
+            <div className="config-list">
+              {(
+                [
+                  ["Account", info.account],
+                  ["Config file", info.configPath],
+                  ["Log file", info.logPath],
+                  [
+                    "LLM",
+                    info.llmModel
+                      ? `${info.llmProvider} · ${info.llmModel}`
+                      : "disabled",
+                  ],
+                  ["Theme", info.theme || "default"],
+                  ["Downloads", info.downloadPath],
+                  ["Obsidian", info.obsidianOn ? "on" : "off"],
+                  ["Slack", info.slackOn ? "on" : "off"],
+                  ["Auto-refresh", info.autoRefresh ? "on" : "off"],
+                ] as [string, string][]
+              ).map(([k, v]) => (
+                <div key={k} className="config-row">
+                  <span className="config-key muted">{k}</span>
+                  <span className="config-val">{v}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+        <div className="modal-foot">
+          <button className="ghost" onClick={onClearCaches}>
+            Clear AI caches
+          </button>
+          <button onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/frontend/src/PromptPreviewModal.tsx
+++ b/desktop/frontend/src/PromptPreviewModal.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from "react";
+
+// The analyzer-prompt preview (opened by :action-plan prompt / the plan's `p`).
+// A long scrollable <pre>; WKWebView won't focus the bare modal body, so arrows/
+// PageUp/etc. are driven from a window-level listener while it's mounted. Escape
+// is handled by the App's global modal chain. Self-contained: the scroll ref +
+// effect live here now.
+export default function PromptPreviewModal({
+  text,
+  onClose,
+}: {
+  text: string;
+  onClose: () => void;
+}) {
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => {
+      const el = bodyRef.current;
+      if (!el) return;
+      const line = 48;
+      const page = el.clientHeight * 0.9;
+      let dy = 0;
+      switch (e.key) {
+        case "ArrowDown": case "j": dy = line; break;
+        case "ArrowUp": case "k": dy = -line; break;
+        case "PageDown": case " ": dy = page; break;
+        case "PageUp": dy = -page; break;
+        case "Home": el.scrollTo({ top: 0 }); e.preventDefault(); return;
+        case "End": el.scrollTo({ top: el.scrollHeight }); e.preventDefault(); return;
+        default: return;
+      }
+      el.scrollBy({ top: dy });
+      e.preventDefault();
+    };
+    window.addEventListener("keydown", h, true);
+    return () => window.removeEventListener("keydown", h, true);
+  }, []);
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-head">
+          <h3>Analyzer prompt</h3>
+          <button className="ghost" onClick={onClose}>
+            ✕
+          </button>
+        </div>
+        <div className="modal-body" ref={bodyRef}>
+          <pre className="summary-text">{text}</pre>
+        </div>
+        <div className="modal-foot">
+          <span className="foot-hint">↑↓ scroll · Esc close</span>
+          <button onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/frontend/src/StatsModal.tsx
+++ b/desktop/frontend/src/StatsModal.tsx
@@ -1,0 +1,62 @@
+import type { UsageStats } from "./api";
+
+// AI prompt-usage stats (opened by :stats). Pure display modal.
+export default function StatsModal({
+  stats,
+  onClose,
+}: {
+  stats: UsageStats | null;
+  onClose: () => void;
+}) {
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="modal narrow"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") onClose();
+        }}
+      >
+        <div className="modal-head">
+          <h3>AI usage</h3>
+          <button className="ghost" onClick={onClose}>
+            ✕
+          </button>
+        </div>
+        <div className="modal-body">
+          {!stats ? (
+            <div className="placeholder">Loading…</div>
+          ) : (
+            <>
+              <div className="stats-summary">
+                <div className="stat-tile">
+                  <span className="stat-num">{stats.totalUsage}</span>
+                  <span className="stat-label muted">total runs</span>
+                </div>
+                <div className="stat-tile">
+                  <span className="stat-num">{stats.uniquePrompts}</span>
+                  <span className="stat-label muted">prompts used</span>
+                </div>
+              </div>
+              <div className="label-list">
+                {stats.topPrompts.length === 0 ? (
+                  <div className="placeholder">No usage yet</div>
+                ) : (
+                  stats.topPrompts.map((p) => (
+                    <div key={p.name} className="stat-row">
+                      <span className="stat-row-name">{p.name}</span>
+                      {p.category && (
+                        <span className="stat-row-cat muted">{p.category}</span>
+                      )}
+                      <span className="stat-row-count">{p.usageCount}</span>
+                    </div>
+                  ))
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/DESKTOP_REFACTOR_PLAN.md
+++ b/docs/DESKTOP_REFACTOR_PLAN.md
@@ -189,8 +189,9 @@ Extract **as behavior-preserving moves**, safest → riskiest, Playwright in fro
   by the e2e AI specs ✅. _If a full relocation is still wanted, it's a dedicated,
   high-care pass — but the ROI is line-moving, not decoupling._
 - [~] **F4** JSX component splits (incremental; each self-contained modal → its own file + e2e)
-  - [x] F4.1 `StatsModal` + `ConfigModal` (display modals; −96 lines; +2 e2e specs, suite now 27)
-  - [ ] remaining inline modals (advanced search, prompt preview, analyzer rules, save-query, action plan) + `<MessageList>` / `<Reader>`
+  - [x] F4.1 `StatsModal` + `ConfigModal` (display modals; −96 lines; +2 e2e specs)
+  - [x] F4.2 `PromptPreviewModal` (self-contained; the keyboard-scroll ref+effect moved in; −41 lines; +1 e2e; suite now 28)
+  - [ ] remaining inline modals (advanced search, analyzer rules, save-query, action plan) + `<MessageList>` / `<Reader>`
 
 ## 8. Safety rules (non-negotiable)
 

--- a/docs/DESKTOP_REFACTOR_PLAN.md
+++ b/docs/DESKTOP_REFACTOR_PLAN.md
@@ -188,7 +188,9 @@ Extract **as behavior-preserving moves**, safest → riskiest, Playwright in fro
   streaming (summarize/runPrompt/touchUp) + refs stay in App **by design**. Guarded
   by the e2e AI specs ✅. _If a full relocation is still wanted, it's a dedicated,
   high-care pass — but the ROI is line-moving, not decoupling._
-- [ ] **F4** JSX component splits
+- [~] **F4** JSX component splits (incremental; each self-contained modal → its own file + e2e)
+  - [x] F4.1 `StatsModal` + `ConfigModal` (display modals; −96 lines; +2 e2e specs, suite now 27)
+  - [ ] remaining inline modals (advanced search, prompt preview, analyzer rules, save-query, action plan) + `<MessageList>` / `<Reader>`
 
 ## 8. Safety rules (non-negotiable)
 


### PR DESCRIPTION
## 📋 Description

First increments of F4 (JSX component splits) from `docs/DESKTOP_REFACTOR_PLAN.md`. Lift self-contained inline modals out of `App.tsx` into their own components. **Zero behavior change.**

- **F4.1 — `StatsModal` + `ConfigModal`:** the two pure display modals (`:stats` AI usage, `:config` configuration). Verbatim JSX moves, 2–3 props each (data + close, plus config's Clear-AI-caches action).
- **F4.2 — `PromptPreviewModal`:** the analyzer-prompt preview (`:action-plan prompt`). Its keyboard-scroll ref + window-listener effect **move into the component** so it's fully self-contained; one App-level `useEffect` + ref removed.

`App.tsx`: **5,402 → 5,265** lines (−137). New `e2e/modals.spec.ts` (3 specs: open via command, Escape closes) — e2e suite **25 → 28**.

## 🧪 Testing
- [x] `npm test` — 51 unit tests green
- [x] `npm run test:e2e` — 28 Playwright specs green (incl. the 3 new modal specs)
- [x] `tsc --noEmit` + `npm run build` clean
- [x] Verbatim JSX moves — no behavior change

## 📝 Related
F4 is incremental; more inline modals (advanced search, analyzer rules, save-query, action plan) and the big `<MessageList>` / `<Reader>` splits remain. Tracked in the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU)_