### PR TITLE
refactor(desktop): extract SaveQueryModal + AnalyzerRulesModal from App.tsx (F4.3)

### DIFF
--- a/desktop/frontend/e2e/modals.spec.ts
+++ b/desktop/frontend/e2e/modals.spec.ts
@@ -33,4 +33,26 @@ test.describe("display modals", () => {
     await page.keyboard.press("Escape");
     await expect(modal).toBeHidden();
   });
+
+  test("':action-plan rules' opens the analyzer-rules modal and Escape closes it", async ({ page }) => {
+    await openApp(page);
+    await runCommand(page, "action-plan rules");
+    const modal = page.locator(".modal-overlay").filter({ hasText: "Analyzer rules" });
+    await expect(modal).toBeVisible();
+    await expect(modal.locator(".prompt-manage-row").first()).toBeVisible();
+    await page.keyboard.press("ArrowDown"); // window-level list nav still works
+    await page.keyboard.press("Escape");
+    await expect(modal).toBeHidden();
+  });
+
+  test("':savequery' opens the save-search dialog once a search is active", async ({ page }) => {
+    await openApp(page);
+    await runCommand(page, "search from:test");
+    await runCommand(page, "savequery");
+    const modal = page.locator(".modal-overlay").filter({ hasText: "Save search" });
+    await expect(modal).toBeVisible();
+    await expect(modal.locator("input").first()).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(modal).toBeHidden();
+  });
 });

--- a/desktop/frontend/src/AnalyzerRulesModal.tsx
+++ b/desktop/frontend/src/AnalyzerRulesModal.tsx
@@ -1,0 +1,107 @@
+import { useEffect } from "react";
+import { useListNav } from "./useListNav";
+import { Icon } from "./Icons";
+import type { AnalyzerRule } from "./api";
+
+// The analyzer preference rules (opened by :action-plan rules). Keyboard-first
+// per the picker premises: useListNav drives ↑↓ from the window (WKWebView won't
+// focus the modal), and d/Delete removes the highlighted rule — but not while
+// typing in the add-rule input. The `rules` / `newRule` state stays in App (this
+// is a behavior-preserving move); only the nav + delete-key wiring live here.
+export default function AnalyzerRulesModal({
+  rules,
+  newRule,
+  onNewRuleChange,
+  onAddRule,
+  onDeleteRule,
+  onClose,
+}: {
+  rules: AnalyzerRule[];
+  newRule: string;
+  onNewRuleChange: (value: string) => void;
+  onAddRule: () => void;
+  onDeleteRule: (id: number) => void;
+  onClose: () => void;
+}) {
+  const nav = useListNav(rules, { onEscape: onClose, windowKeys: true });
+
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => {
+      const ae = document.activeElement;
+      if (ae && (ae.tagName === "INPUT" || ae.tagName === "TEXTAREA")) return;
+      if (e.key === "d" || e.key === "Delete" || e.key === "Backspace") {
+        const r = rules[nav.active];
+        if (r) {
+          e.preventDefault();
+          onDeleteRule(r.id);
+        }
+      }
+    };
+    window.addEventListener("keydown", h, true);
+    return () => window.removeEventListener("keydown", h, true);
+  }, [rules, nav.active, onDeleteRule]);
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="modal narrow"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") onClose();
+        }}
+      >
+        <div className="modal-head">
+          <h3>Analyzer rules</h3>
+          <button className="ghost" onClick={onClose}>
+            ✕
+          </button>
+        </div>
+        <div className="modal-body">
+          <div className="muted plan-summary">
+            Natural-language preferences the analyzer follows when planning.
+          </div>
+          <div className="label-list" ref={nav.listRef}>
+            {rules.length === 0 ? (
+              <div className="placeholder">No rules yet</div>
+            ) : (
+              rules.map((r, i) => (
+                <div
+                  key={r.id}
+                  className={
+                    "prompt-manage-row" + (i === nav.active ? " nav-active" : "")
+                  }
+                  onMouseEnter={() => nav.setActiveHover(i)}
+                >
+                  <span className="rule-text">{r.text}</span>
+                  <button
+                    className="ghost tiny danger"
+                    title="Delete"
+                    onClick={() => onDeleteRule(r.id)}
+                  >
+                    {Icon.trash}
+                  </button>
+                </div>
+              ))
+            )}
+          </div>
+          <div className="field">
+            <input
+              value={newRule}
+              onChange={(e) => onNewRuleChange(e.target.value)}
+              placeholder="e.g. Always archive newsletters"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") onAddRule();
+              }}
+            />
+          </div>
+        </div>
+        <div className="modal-foot">
+          <span className="foot-hint">↑↓ move · d delete · Esc close</span>
+          <button onClick={onAddRule} disabled={!newRule.trim()}>
+            Add rule
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -54,6 +54,8 @@ import { activeAiPanel } from "./aiPanels";
 import StatsModal from "./StatsModal";
 import ConfigModal from "./ConfigModal";
 import PromptPreviewModal from "./PromptPreviewModal";
+import SaveQueryModal from "./SaveQueryModal";
+import AnalyzerRulesModal from "./AnalyzerRulesModal";
 import {
   buildMoveTargets,
   applyPlanMove,
@@ -2104,29 +2106,6 @@ export default function App() {
   // Keyboard nav for the analyzer-rules modal: WKWebView won't focus the bare
   // modal, so drive arrows from the window (useListNav) and highlight the active
   // row. Escape closes.
-  const rulesNav = useListNav(rules, {
-    onEscape: () => setRulesOpen(false),
-    windowKeys: rulesOpen,
-  });
-  // Delete the highlighted rule with d / Delete — but not while typing in the
-  // add-rule field, so those keys still edit the text there.
-  useEffect(() => {
-    if (!rulesOpen) return;
-    const h = (e: KeyboardEvent) => {
-      const ae = document.activeElement;
-      if (ae && (ae.tagName === "INPUT" || ae.tagName === "TEXTAREA")) return;
-      if (e.key === "d" || e.key === "Delete" || e.key === "Backspace") {
-        const r = rules[rulesNav.active];
-        if (r) {
-          e.preventDefault();
-          void deleteRule(r.id);
-        }
-      }
-    };
-    window.addEventListener("keydown", h, true);
-    return () => window.removeEventListener("keydown", h, true);
-  }, [rulesOpen, rules, rulesNav.active, deleteRule]);
-
   const viewAnalyzerPrompt = useCallback(async () => {
     try {
       setPromptPreview(await backend.ViewAnalyzerPrompt());
@@ -4601,46 +4580,13 @@ export default function App() {
         />
       )}
       {saveQueryOpen && (
-        <div className="modal-overlay" onClick={() => setSaveQueryOpen(false)}>
-          <div
-            className="modal narrow"
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => {
-              if (e.key === "Escape") setSaveQueryOpen(false);
-              else if (e.key === "Enter") doSaveQuery();
-            }}
-          >
-            <div className="modal-head">
-              <h3>Save search</h3>
-              <button className="ghost" onClick={() => setSaveQueryOpen(false)}>
-                ✕
-              </button>
-            </div>
-            <div className="modal-body">
-              <div className="field">
-                <label>Name</label>
-                <input
-                  value={saveQueryName}
-                  onChange={(e) => setSaveQueryName(e.target.value)}
-                  placeholder="e.g. Unread from team"
-                  autoFocus
-                />
-              </div>
-              <div className="field readonly">
-                <label>Query</label>
-                <div className="ro-value">{activeQuery}</div>
-              </div>
-            </div>
-            <div className="modal-foot">
-              <button className="ghost" onClick={() => setSaveQueryOpen(false)}>
-                Cancel
-              </button>
-              <button onClick={doSaveQuery} disabled={!saveQueryName.trim()}>
-                Save
-              </button>
-            </div>
-          </div>
-        </div>
+        <SaveQueryModal
+          name={saveQueryName}
+          onNameChange={setSaveQueryName}
+          query={activeQuery}
+          onSave={doSaveQuery}
+          onClose={() => setSaveQueryOpen(false)}
+        />
       )}
       {bulkPromptText !== null && (
         <div className="modal-overlay" onClick={() => setBulkPromptText(null)}>
@@ -5016,68 +4962,14 @@ export default function App() {
         />
       )}
       {rulesOpen && (
-        <div className="modal-overlay" onClick={() => setRulesOpen(false)}>
-          <div
-            className="modal narrow"
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => {
-              if (e.key === "Escape") setRulesOpen(false);
-            }}
-          >
-            <div className="modal-head">
-              <h3>Analyzer rules</h3>
-              <button className="ghost" onClick={() => setRulesOpen(false)}>
-                ✕
-              </button>
-            </div>
-            <div className="modal-body">
-              <div className="muted plan-summary">
-                Natural-language preferences the analyzer follows when planning.
-              </div>
-              <div className="label-list" ref={rulesNav.listRef}>
-                {rules.length === 0 ? (
-                  <div className="placeholder">No rules yet</div>
-                ) : (
-                  rules.map((r, i) => (
-                    <div
-                      key={r.id}
-                      className={
-                        "prompt-manage-row" +
-                        (i === rulesNav.active ? " nav-active" : "")
-                      }
-                      onMouseEnter={() => rulesNav.setActiveHover(i)}
-                    >
-                      <span className="rule-text">{r.text}</span>
-                      <button
-                        className="ghost tiny danger"
-                        title="Delete"
-                        onClick={() => void deleteRule(r.id)}
-                      >
-                        {Icon.trash}
-                      </button>
-                    </div>
-                  ))
-                )}
-              </div>
-              <div className="field">
-                <input
-                  value={newRule}
-                  onChange={(e) => setNewRule(e.target.value)}
-                  placeholder="e.g. Always archive newsletters"
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") void addRule();
-                  }}
-                />
-              </div>
-            </div>
-            <div className="modal-foot">
-              <span className="foot-hint">↑↓ move · d delete · Esc close</span>
-              <button onClick={() => void addRule()} disabled={!newRule.trim()}>
-                Add rule
-              </button>
-            </div>
-          </div>
-        </div>
+        <AnalyzerRulesModal
+          rules={rules}
+          newRule={newRule}
+          onNewRuleChange={setNewRule}
+          onAddRule={() => void addRule()}
+          onDeleteRule={(id) => void deleteRule(id)}
+          onClose={() => setRulesOpen(false)}
+        />
       )}
       {promptPreview !== null && (
         <PromptPreviewModal

--- a/desktop/frontend/src/SaveQueryModal.tsx
+++ b/desktop/frontend/src/SaveQueryModal.tsx
@@ -1,0 +1,59 @@
+// Name-and-save dialog for the current Gmail search (opened by :savequery).
+// Presentational: the name state stays in App (behavior-preserving pure move),
+// so this component just renders and forwards events.
+export default function SaveQueryModal({
+  name,
+  onNameChange,
+  query,
+  onSave,
+  onClose,
+}: {
+  name: string;
+  onNameChange: (value: string) => void;
+  query: string;
+  onSave: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="modal narrow"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") onClose();
+          else if (e.key === "Enter") onSave();
+        }}
+      >
+        <div className="modal-head">
+          <h3>Save search</h3>
+          <button className="ghost" onClick={onClose}>
+            ✕
+          </button>
+        </div>
+        <div className="modal-body">
+          <div className="field">
+            <label>Name</label>
+            <input
+              value={name}
+              onChange={(e) => onNameChange(e.target.value)}
+              placeholder="e.g. Unread from team"
+              autoFocus
+            />
+          </div>
+          <div className="field readonly">
+            <label>Query</label>
+            <div className="ro-value">{query}</div>
+          </div>
+        </div>
+        <div className="modal-foot">
+          <button className="ghost" onClick={onClose}>
+            Cancel
+          </button>
+          <button onClick={onSave} disabled={!name.trim()}>
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/DESKTOP_REFACTOR_PLAN.md
+++ b/docs/DESKTOP_REFACTOR_PLAN.md
@@ -190,8 +190,9 @@ Extract **as behavior-preserving moves**, safest → riskiest, Playwright in fro
   high-care pass — but the ROI is line-moving, not decoupling._
 - [~] **F4** JSX component splits (incremental; each self-contained modal → its own file + e2e)
   - [x] F4.1 `StatsModal` + `ConfigModal` (display modals; −96 lines; +2 e2e specs)
-  - [x] F4.2 `PromptPreviewModal` (self-contained; the keyboard-scroll ref+effect moved in; −41 lines; +1 e2e; suite now 28)
-  - [ ] remaining inline modals (advanced search, analyzer rules, save-query, action plan) + `<MessageList>` / `<Reader>`
+  - [x] F4.2 `PromptPreviewModal` (self-contained; the keyboard-scroll ref+effect moved in; −41 lines; +1 e2e)
+  - [x] F4.3 `SaveQueryModal` (presentational pure move) + `AnalyzerRulesModal` (owns its useListNav + delete-key effect); −108 lines; +2 e2e; suite now 30
+  - [ ] remaining inline modals (advanced search, action plan) + `<MessageList>` / `<Reader>`
 
 ## 8. Safety rules (non-negotiable)
 


### PR DESCRIPTION
## 📋 Description

Continues F4 (JSX component splits). **Zero behavior change.**

- **`SaveQueryModal`** (`:savequery`): presentational pure move — the name input state stays in App, so it's behavior-identical.
- **`AnalyzerRulesModal`** (`:action-plan rules`): self-contained — its `useListNav` and the `d`/`Delete` window-listener effect **move into the component**. They only ran while the modal was open, so `windowKeys`/the effect become unconditional-on-mount, which is equivalent. The `rules` / `newRule` state + add/delete handlers stay in App.

`App.tsx`: **5,265 → 5,157** lines (−108). Two App-level hooks removed (a `useListNav` + a `useEffect`). e2e suite **28 → 30** (added `:action-plan rules` nav + `:savequery`-after-search specs).

## 🧪 Testing
- [x] `npm test` — 51 unit green
- [x] `npm run test:e2e` — 30 Playwright specs green
- [x] `tsc --noEmit` + `npm run build` clean
- [x] No behavior change (pure move + a hook relocation that's equivalent while mounted)

## 📝 Related
F4 remaining: advanced-search + action-plan modals, then the big `<MessageList>` / `<Reader>` splits. Tracked in the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU)_