### PR TITLE
refactor(desktop): extract AdvancedSearchModal + pure buildAdvancedQuery (F4.4)

### DIFF
--- a/desktop/frontend/e2e/modals.spec.ts
+++ b/desktop/frontend/e2e/modals.spec.ts
@@ -55,4 +55,16 @@ test.describe("display modals", () => {
     await page.keyboard.press("Escape");
     await expect(modal).toBeHidden();
   });
+
+  test("':advanced' opens the builder and previews the query as you type", async ({ page }) => {
+    await openApp(page);
+    await runCommand(page, "advanced");
+    const modal = page.locator(".modal-overlay").filter({ hasText: "Advanced search" });
+    await expect(modal).toBeVisible();
+    // Typing a From value updates the live query preview.
+    await modal.locator(".field", { hasText: "From" }).locator("input").fill("boss@x.com");
+    await expect(modal.locator(".ro-value")).toHaveText("from:boss@x.com");
+    await page.keyboard.press("Escape");
+    await expect(modal).toBeHidden();
+  });
 });

--- a/desktop/frontend/src/AdvancedSearchModal.tsx
+++ b/desktop/frontend/src/AdvancedSearchModal.tsx
@@ -1,0 +1,111 @@
+import { buildAdvancedQuery, type AdvFilters } from "./advancedSearch";
+
+// Advanced search builder (opened by Ctrl+F / :advanced). Presentational: the
+// `adv` form state stays in App (behavior-preserving move); this renders the
+// form, previews the built query, and hands the final query to onSearch.
+export default function AdvancedSearchModal({
+  adv,
+  onChange,
+  onSearch,
+  onClose,
+}: {
+  adv: AdvFilters;
+  onChange: (next: AdvFilters) => void;
+  onSearch: (query: string) => void;
+  onClose: () => void;
+}) {
+  const query = buildAdvancedQuery(adv);
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="modal narrow"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") onClose();
+        }}
+      >
+        <div className="modal-head">
+          <h3>Advanced search</h3>
+          <button className="ghost" onClick={onClose}>
+            ✕
+          </button>
+        </div>
+        <div className="modal-body">
+          <div className="field">
+            <label>From</label>
+            <input
+              value={adv.from}
+              onChange={(e) => onChange({ ...adv, from: e.target.value })}
+              placeholder="sender@example.com"
+              autoFocus
+            />
+          </div>
+          <div className="field">
+            <label>To</label>
+            <input
+              value={adv.to}
+              onChange={(e) => onChange({ ...adv, to: e.target.value })}
+              placeholder="recipient@example.com"
+            />
+          </div>
+          <div className="field">
+            <label>Subject</label>
+            <input
+              value={adv.subject}
+              onChange={(e) => onChange({ ...adv, subject: e.target.value })}
+              placeholder="words in the subject"
+            />
+          </div>
+          <div className="adv-row">
+            <label className="adv-check">
+              <input
+                type="checkbox"
+                checked={adv.hasAttachment}
+                onChange={(e) => onChange({ ...adv, hasAttachment: e.target.checked })}
+              />
+              Has attachment
+            </label>
+            <label className="adv-check">
+              <input
+                type="checkbox"
+                checked={adv.unreadOnly}
+                onChange={(e) => onChange({ ...adv, unreadOnly: e.target.checked })}
+              />
+              Unread only
+            </label>
+          </div>
+          <div className="adv-row">
+            <div className="field">
+              <label>After</label>
+              <input
+                type="date"
+                value={adv.after}
+                onChange={(e) => onChange({ ...adv, after: e.target.value })}
+              />
+            </div>
+            <div className="field">
+              <label>Before</label>
+              <input
+                type="date"
+                value={adv.before}
+                onChange={(e) => onChange({ ...adv, before: e.target.value })}
+              />
+            </div>
+          </div>
+          <div className="field readonly">
+            <label>Query preview</label>
+            <div className="ro-value">{query || "(empty)"}</div>
+          </div>
+        </div>
+        <div className="modal-foot">
+          <button className="ghost" onClick={onClose}>
+            Cancel
+          </button>
+          <button onClick={() => onSearch(query)} disabled={!query}>
+            Search
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -56,6 +56,8 @@ import ConfigModal from "./ConfigModal";
 import PromptPreviewModal from "./PromptPreviewModal";
 import SaveQueryModal from "./SaveQueryModal";
 import AnalyzerRulesModal from "./AnalyzerRulesModal";
+import AdvancedSearchModal from "./AdvancedSearchModal";
+import { type AdvFilters, EMPTY_ADV } from "./advancedSearch";
 import {
   buildMoveTargets,
   applyPlanMove,
@@ -319,15 +321,7 @@ export default function App() {
   // running a remote Gmail search (the TUI's search_toggle_mode).
   const [localFilter, setLocalFilter] = useState(false);
   const [advOpen, setAdvOpen] = useState(false);
-  const [adv, setAdv] = useState({
-    from: "",
-    to: "",
-    subject: "",
-    hasAttachment: false,
-    unreadOnly: false,
-    after: "",
-    before: "",
-  });
+  const [adv, setAdv] = useState<AdvFilters>(EMPTY_ADV);
   const fullMessagesRef = useRef<MessageSummary[]>([]);
   // Background inbox auto-refresh (opt-in; seeded from config, then remembered).
   const [autoRefresh, setAutoRefresh] = useState(false);
@@ -532,19 +526,6 @@ export default function App() {
   }, []);
 
   // buildAdvancedQuery assembles a Gmail search string from the builder fields.
-  const buildAdvancedQuery = useCallback((): string => {
-    const parts: string[] = [];
-    if (adv.from.trim()) parts.push(`from:${adv.from.trim()}`);
-    if (adv.to.trim()) parts.push(`to:${adv.to.trim()}`);
-    if (adv.subject.trim()) parts.push(`subject:(${adv.subject.trim()})`);
-    if (adv.hasAttachment) parts.push("has:attachment");
-    if (adv.unreadOnly) parts.push("is:unread");
-    if (adv.after.trim()) parts.push(`after:${adv.after.trim().replace(/-/g, "/")}`);
-    if (adv.before.trim())
-      parts.push(`before:${adv.before.trim().replace(/-/g, "/")}`);
-    return parts.join(" ");
-  }, [adv]);
-
   const toggleAutoRefresh = useCallback(() => {
     setAutoRefresh((v) => {
       const next = !v;
@@ -5012,113 +4993,18 @@ export default function App() {
         />
       )}
       {advOpen && (
-        <div className="modal-overlay" onClick={() => setAdvOpen(false)}>
-          <div
-            className="modal narrow"
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => {
-              if (e.key === "Escape") setAdvOpen(false);
-            }}
-          >
-            <div className="modal-head">
-              <h3>Advanced search</h3>
-              <button className="ghost" onClick={() => setAdvOpen(false)}>
-                ✕
-              </button>
-            </div>
-            <div className="modal-body">
-              <div className="field">
-                <label>From</label>
-                <input
-                  value={adv.from}
-                  onChange={(e) => setAdv({ ...adv, from: e.target.value })}
-                  placeholder="sender@example.com"
-                  autoFocus
-                />
-              </div>
-              <div className="field">
-                <label>To</label>
-                <input
-                  value={adv.to}
-                  onChange={(e) => setAdv({ ...adv, to: e.target.value })}
-                  placeholder="recipient@example.com"
-                />
-              </div>
-              <div className="field">
-                <label>Subject</label>
-                <input
-                  value={adv.subject}
-                  onChange={(e) => setAdv({ ...adv, subject: e.target.value })}
-                  placeholder="words in the subject"
-                />
-              </div>
-              <div className="adv-row">
-                <label className="adv-check">
-                  <input
-                    type="checkbox"
-                    checked={adv.hasAttachment}
-                    onChange={(e) =>
-                      setAdv({ ...adv, hasAttachment: e.target.checked })
-                    }
-                  />
-                  Has attachment
-                </label>
-                <label className="adv-check">
-                  <input
-                    type="checkbox"
-                    checked={adv.unreadOnly}
-                    onChange={(e) =>
-                      setAdv({ ...adv, unreadOnly: e.target.checked })
-                    }
-                  />
-                  Unread only
-                </label>
-              </div>
-              <div className="adv-row">
-                <div className="field">
-                  <label>After</label>
-                  <input
-                    type="date"
-                    value={adv.after}
-                    onChange={(e) => setAdv({ ...adv, after: e.target.value })}
-                  />
-                </div>
-                <div className="field">
-                  <label>Before</label>
-                  <input
-                    type="date"
-                    value={adv.before}
-                    onChange={(e) => setAdv({ ...adv, before: e.target.value })}
-                  />
-                </div>
-              </div>
-              <div className="field readonly">
-                <label>Query preview</label>
-                <div className="ro-value">
-                  {buildAdvancedQuery() || "(empty)"}
-                </div>
-              </div>
-            </div>
-            <div className="modal-foot">
-              <button className="ghost" onClick={() => setAdvOpen(false)}>
-                Cancel
-              </button>
-              <button
-                onClick={() => {
-                  const q = buildAdvancedQuery();
-                  if (!q) return;
-                  setLocalFilter(false);
-                  setQuery(q);
-                  setAdvOpen(false);
-                  void load(q);
-                }}
-                disabled={!buildAdvancedQuery()}
-              >
-                Search
-              </button>
-            </div>
-          </div>
-        </div>
+        <AdvancedSearchModal
+          adv={adv}
+          onChange={setAdv}
+          onSearch={(q) => {
+            if (!q) return;
+            setLocalFilter(false);
+            setQuery(q);
+            setAdvOpen(false);
+            void load(q);
+          }}
+          onClose={() => setAdvOpen(false)}
+        />
       )}
       {statsOpen && (
         <StatsModal stats={stats} onClose={() => setStatsOpen(false)} />

--- a/desktop/frontend/src/advancedSearch.test.ts
+++ b/desktop/frontend/src/advancedSearch.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { buildAdvancedQuery, EMPTY_ADV, type AdvFilters } from "./advancedSearch";
+
+const adv = (o: Partial<AdvFilters>): AdvFilters => ({ ...EMPTY_ADV, ...o });
+
+describe("buildAdvancedQuery", () => {
+  it("is empty for empty filters", () => {
+    expect(buildAdvancedQuery(EMPTY_ADV)).toBe("");
+  });
+  it("builds from/to and wraps subject in parens", () => {
+    expect(buildAdvancedQuery(adv({ from: "a@x.com" }))).toBe("from:a@x.com");
+    expect(buildAdvancedQuery(adv({ to: "b@x.com" }))).toBe("to:b@x.com");
+    expect(buildAdvancedQuery(adv({ subject: "project update" }))).toBe(
+      "subject:(project update)",
+    );
+  });
+  it("emits the has:attachment / is:unread flags", () => {
+    expect(buildAdvancedQuery(adv({ hasAttachment: true }))).toBe("has:attachment");
+    expect(buildAdvancedQuery(adv({ unreadOnly: true }))).toBe("is:unread");
+  });
+  it("rewrites dates from yyyy-mm-dd to Gmail's yyyy/mm/dd", () => {
+    expect(buildAdvancedQuery(adv({ after: "2026-07-01" }))).toBe("after:2026/07/01");
+    expect(buildAdvancedQuery(adv({ before: "2026-07-31" }))).toBe("before:2026/07/31");
+  });
+  it("trims inputs and joins all parts in order with spaces", () => {
+    const q = buildAdvancedQuery(
+      adv({
+        from: "  a@x.com ",
+        subject: " hi ",
+        hasAttachment: true,
+        unreadOnly: true,
+        after: "2026-01-02",
+      }),
+    );
+    expect(q).toBe("from:a@x.com subject:(hi) has:attachment is:unread after:2026/01/02");
+  });
+});

--- a/desktop/frontend/src/advancedSearch.ts
+++ b/desktop/frontend/src/advancedSearch.ts
@@ -1,0 +1,37 @@
+// Advanced-search filters and the pure Gmail-query builder, extracted from
+// App.tsx so the query construction is unit-tested in isolation.
+
+export interface AdvFilters {
+  from: string;
+  to: string;
+  subject: string;
+  hasAttachment: boolean;
+  unreadOnly: boolean;
+  after: string; // yyyy-mm-dd (from an <input type=date>)
+  before: string;
+}
+
+export const EMPTY_ADV: AdvFilters = {
+  from: "",
+  to: "",
+  subject: "",
+  hasAttachment: false,
+  unreadOnly: false,
+  after: "",
+  before: "",
+};
+
+// buildAdvancedQuery turns the form into a Gmail search string. Dates are
+// rewritten from the input's yyyy-mm-dd to Gmail's yyyy/mm/dd.
+export function buildAdvancedQuery(adv: AdvFilters): string {
+  const parts: string[] = [];
+  if (adv.from.trim()) parts.push(`from:${adv.from.trim()}`);
+  if (adv.to.trim()) parts.push(`to:${adv.to.trim()}`);
+  if (adv.subject.trim()) parts.push(`subject:(${adv.subject.trim()})`);
+  if (adv.hasAttachment) parts.push("has:attachment");
+  if (adv.unreadOnly) parts.push("is:unread");
+  if (adv.after.trim()) parts.push(`after:${adv.after.trim().replace(/-/g, "/")}`);
+  if (adv.before.trim())
+    parts.push(`before:${adv.before.trim().replace(/-/g, "/")}`);
+  return parts.join(" ");
+}

--- a/docs/DESKTOP_REFACTOR_PLAN.md
+++ b/docs/DESKTOP_REFACTOR_PLAN.md
@@ -191,8 +191,9 @@ Extract **as behavior-preserving moves**, safest → riskiest, Playwright in fro
 - [~] **F4** JSX component splits (incremental; each self-contained modal → its own file + e2e)
   - [x] F4.1 `StatsModal` + `ConfigModal` (display modals; −96 lines; +2 e2e specs)
   - [x] F4.2 `PromptPreviewModal` (self-contained; the keyboard-scroll ref+effect moved in; −41 lines; +1 e2e)
-  - [x] F4.3 `SaveQueryModal` (presentational pure move) + `AnalyzerRulesModal` (owns its useListNav + delete-key effect); −108 lines; +2 e2e; suite now 30
-  - [ ] remaining inline modals (advanced search, action plan) + `<MessageList>` / `<Reader>`
+  - [x] F4.3 `SaveQueryModal` (presentational pure move) + `AnalyzerRulesModal` (owns its useListNav + delete-key effect); −108 lines; +2 e2e
+  - [x] F4.4 `AdvancedSearchModal` + pure `buildAdvancedQuery` in `advancedSearch.ts` (5 unit tests); −114 lines; +1 e2e; unit 56 / e2e 31
+  - [ ] remaining: action-plan modal (~340 lines, prop-heavy) + `<MessageList>` / `<Reader>`
 
 ## 8. Safety rules (non-negotiable)
 


### PR DESCRIPTION
## 📋 Description

Continues F4. **Zero behavior change.**

- Extracted the Gmail-query builder into `advancedSearch.ts` as a **pure** `buildAdvancedQuery(adv)` (+ `AdvFilters` / `EMPTY_ADV`), and unit-tested it: empty, from/to, `subject:(…)` parens, `has:attachment` / `is:unread` flags, `yyyy-mm-dd → yyyy/mm/dd` date rewrite, trim + join order.
- Lifted the builder modal into `AdvancedSearchModal.tsx` (presentational — the `adv` form state stays in App).

`App.tsx`: **5,157 → 5,043** lines (−114). unit **51 → 56**, e2e **30 → 31** (added `:advanced` opens + live query-preview spec).

## 🧪 Testing
- [x] `npm test` — 56 unit green
- [x] `npm run test:e2e` — 31 Playwright specs green
- [x] `tsc --noEmit` + `npm run build` clean
- [x] No behavior change

## 📝 Related
F4 remaining: the action-plan modal (~340 lines, prop-heavy) + the big `<MessageList>` / `<Reader>` splits. Tracked in the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU)_