### PR TITLE
refactor(desktop): extract peripheral hooks from App.tsx (F5.1)

### DIFF
--- a/desktop/frontend/e2e/drafts.spec.ts
+++ b/desktop/frontend/e2e/drafts.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+import { openApp, runCommand } from "./helpers";
+
+// Drafts subsystem (useDrafts). Guards the F5.1 hook extraction: :drafts shows
+// the drafts pane, opening a draft loads it into the composer, and "Back to
+// inbox" restores the list.
+test.describe("drafts", () => {
+  test("':drafts' lists drafts; opening one loads the composer", async ({ page }) => {
+    await openApp(page);
+    await runCommand(page, "drafts");
+
+    // The left pane flips to drafts: a "Drafts" header + the mock's draft rows.
+    await expect(page.locator(".bulk-count", { hasText: "Drafts" })).toBeVisible();
+    const draftRows = page.locator(".list .row");
+    await expect(draftRows.first()).toBeVisible();
+    expect(await draftRows.count()).toBeGreaterThan(1);
+
+    // Clicking a draft opens the composer in "Edit draft" mode.
+    await draftRows.first().click();
+    const composer = page.locator(".modal-overlay").filter({ hasText: "Edit draft" });
+    await expect(composer).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(composer).toBeHidden();
+
+    // "Back to inbox" leaves the drafts view.
+    await page.locator("button", { hasText: "Back to inbox" }).click();
+    await expect(page.locator(".bulk-count", { hasText: "Drafts" })).toBeHidden();
+  });
+});

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -7,7 +7,6 @@ import {
   summarizeStream,
   threadSummaryStream,
   type AccountInfo,
-  type DraftSummary,
   type KeyMap,
   type Label,
   type UsageStats,
@@ -58,6 +57,10 @@ import ActionPlanModal from "./ActionPlanModal";
 import MessageList from "./MessageList";
 import Reader from "./Reader";
 import TopBar from "./TopBar";
+import { useUndo } from "./useUndo";
+import { useIntegrations } from "./useIntegrations";
+import { useAutoRefresh } from "./useAutoRefresh";
+import { useDrafts } from "./useDrafts";
 import { type AdvFilters, EMPTY_ADV } from "./advancedSearch";
 import {
   buildMoveTargets,
@@ -199,14 +202,9 @@ export default function App() {
     },
     [],
   );
-  const [draftsView, setDraftsView] = useState(false);
-  const [drafts, setDrafts] = useState<DraftSummary[]>([]);
-  const [loadingDrafts, setLoadingDrafts] = useState(false);
   const [keymap, setKeymap] = useState<KeyMap>(DEFAULT_KEYMAP);
   const [appVersion, setAppVersion] = useState("");
   const [linksFor, setLinksFor] = useState<string | null>(null);
-  const [obsidianOn, setObsidianOn] = useState(false);
-  const [slackOn, setSlackOn] = useState(false);
   const [suggestFor, setSuggestFor] = useState<string | null>(null);
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [loadingSuggest, setLoadingSuggest] = useState(false);
@@ -320,8 +318,6 @@ export default function App() {
   const [adv, setAdv] = useState<AdvFilters>(EMPTY_ADV);
   const fullMessagesRef = useRef<MessageSummary[]>([]);
   // Background inbox auto-refresh (opt-in; seeded from config, then remembered).
-  const [autoRefresh, setAutoRefresh] = useState(false);
-  const [autoRefreshSecs, setAutoRefreshSecs] = useState(60);
   const toggleToolbar = useCallback(() => {
     setShowToolbar((v) => {
       const next = !v;
@@ -385,6 +381,18 @@ export default function App() {
     setToast(msg);
     setTimeout(() => setToast(""), 2500);
   }, []);
+
+  const { obsidianOn, slackOn, refresh: refreshIntegrations, sendObsidian, forwardSlack } =
+    useIntegrations({ showToast, setError });
+  const {
+    draftsView,
+    setDraftsView,
+    drafts,
+    loadingDrafts,
+    loadDrafts,
+    openDrafts,
+    openDraft,
+  } = useDrafts({ setError, setSelectedId, setDetail, setCompose });
 
   // Per-message subsystems extracted from App.tsx (F3.2). Their per-message data
   // is still fetched inside loadMessage (gated by openIdRef) via the setters
@@ -522,15 +530,6 @@ export default function App() {
   }, []);
 
   // buildAdvancedQuery assembles a Gmail search string from the builder fields.
-  const toggleAutoRefresh = useCallback(() => {
-    setAutoRefresh((v) => {
-      const next = !v;
-      localStorage.setItem("giztui.autorefresh", next ? "on" : "off");
-      showToast(next ? "Auto-refresh on" : "Auto-refresh off");
-      return next;
-    });
-  }, [showToast]);
-
   // checkNewMail polls the inbox's first page and prepends any messages we don't
   // already have. Only runs on the plain inbox (no active search / drafts view).
   const checkNewMail = useCallback(async () => {
@@ -565,12 +564,13 @@ export default function App() {
     });
   }, []);
 
-  useEffect(() => {
-    if (!autoRefresh) return;
-    const ms = Math.max(30, autoRefreshSecs) * 1000;
-    const timer = setInterval(() => void checkNewMail(), ms);
-    return () => clearInterval(timer);
-  }, [autoRefresh, autoRefreshSecs, checkNewMail]);
+  const {
+    autoRefresh,
+    setAutoRefresh,
+    autoRefreshSecs,
+    setAutoRefreshSecs,
+    toggleAutoRefresh,
+  } = useAutoRefresh({ showToast, onTick: () => void checkNewMail() });
 
   const runInit = useCallback(async () => {
     // Reset to the connecting state (also covers retry-after-import).
@@ -647,8 +647,7 @@ export default function App() {
         /* non-fatal */
       }
       try {
-        setObsidianOn(await backend.ObsidianEnabled());
-        setSlackOn(await backend.SlackEnabled());
+        await refreshIntegrations();
         setThreadingOn(await backend.ThreadingEnabled());
         setSavedQueriesOn(await backend.SavedQueriesEnabled());
         setActionPlanOn(await backend.ActionPlanEnabled());
@@ -910,34 +909,7 @@ export default function App() {
 
   // Undo stack: each mutating action pushes a reversal closure; the undo key runs
   // the most recent one (GizTUI's "U").
-  const undoRef = useRef<{ label: string; run: () => Promise<void> }[]>([]);
-  const [undoLabel, setUndoLabel] = useState("");
-  const pushUndo = useCallback(
-    (label: string, run: () => Promise<void>) => {
-      undoRef.current.push({ label, run });
-      if (undoRef.current.length > 25) undoRef.current.shift();
-      setUndoLabel(label);
-    },
-    [],
-  );
-  const runUndo = useCallback(async () => {
-    const entry = undoRef.current.pop();
-    setUndoLabel(
-      undoRef.current.length
-        ? undoRef.current[undoRef.current.length - 1].label
-        : "",
-    );
-    if (!entry) {
-      showToast("Nothing to undo");
-      return;
-    }
-    try {
-      await entry.run();
-      showToast(`Undone: ${entry.label}`);
-    } catch (e) {
-      setError(String(e));
-    }
-  }, [showToast]);
+  const { undoLabel, pushUndo, runUndo } = useUndo({ showToast, setError });
 
   const doAction = useCallback(
     async (action: "archive" | "trash" | "read" | "unread", id: string) => {
@@ -1415,42 +1387,6 @@ export default function App() {
     [load],
   );
 
-  const loadDrafts = useCallback(async () => {
-    setLoadingDrafts(true);
-    setError("");
-    try {
-      setDrafts(await backend.ListDrafts());
-    } catch (e) {
-      setError(String(e));
-    } finally {
-      setLoadingDrafts(false);
-    }
-  }, []);
-
-  const openDrafts = useCallback(() => {
-    setDraftsView(true);
-    setSelectedId(null);
-    setDetail(null);
-    void loadDrafts();
-  }, [loadDrafts]);
-
-  const openDraft = useCallback(async (d: DraftSummary) => {
-    setError("");
-    try {
-      const det = await backend.GetDraft(d.id);
-      setCompose({
-        mode: "draft",
-        draftId: det.id,
-        to: det.to,
-        cc: det.cc,
-        subject: det.subject,
-        body: det.body,
-      });
-    } catch (e) {
-      setError(String(e));
-    }
-  }, []);
-
   const openInGmail = useCallback((id: string) => {
     void backend.OpenGmailWeb(id).catch((e) => setError(String(e)));
   }, []);
@@ -1634,28 +1570,6 @@ export default function App() {
       void backend
         .SaveRawMessage(id)
         .then((path) => showToast(`Saved .eml to ${path}`))
-        .catch((e) => setError(String(e)));
-    },
-    [showToast],
-  );
-
-  const sendObsidian = useCallback(
-    (id: string) => {
-      showToast("Sending to Obsidian…");
-      void backend
-        .SendToObsidian(id)
-        .then((p) => showToast(p ? `Saved to Obsidian: ${p}` : "Saved to Obsidian"))
-        .catch((e) => setError(String(e)));
-    },
-    [showToast],
-  );
-
-  const forwardSlack = useCallback(
-    (id: string) => {
-      showToast("Forwarding to Slack…");
-      void backend
-        .ForwardToSlack(id)
-        .then(() => showToast("Forwarded to Slack"))
         .catch((e) => setError(String(e)));
     },
     [showToast],

--- a/desktop/frontend/src/useAutoRefresh.ts
+++ b/desktop/frontend/src/useAutoRefresh.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from "react";
+
+// useAutoRefresh owns the background inbox poll: whether it's on, the interval,
+// and the toggle (which persists the on/off choice to localStorage). The actual
+// poll (checkNewMail) stays in App and is passed as onTick, since it reads the
+// message/search subsystem. Extracted from App.tsx unchanged. setAutoRefresh /
+// setAutoRefreshSecs are exposed so init can seed them from config.
+export interface AutoRefresh {
+  autoRefresh: boolean;
+  setAutoRefresh: Dispatch<SetStateAction<boolean>>;
+  autoRefreshSecs: number;
+  setAutoRefreshSecs: Dispatch<SetStateAction<number>>;
+  toggleAutoRefresh: () => void;
+}
+
+export function useAutoRefresh(deps: {
+  showToast: (m: string) => void;
+  onTick: () => void;
+}): AutoRefresh {
+  const { showToast, onTick } = deps;
+  const [autoRefresh, setAutoRefresh] = useState(false);
+  const [autoRefreshSecs, setAutoRefreshSecs] = useState(60);
+
+  const toggleAutoRefresh = useCallback(() => {
+    setAutoRefresh((v) => {
+      const next = !v;
+      localStorage.setItem("giztui.autorefresh", next ? "on" : "off");
+      showToast(next ? "Auto-refresh on" : "Auto-refresh off");
+      return next;
+    });
+  }, [showToast]);
+
+  useEffect(() => {
+    if (!autoRefresh) return;
+    const ms = Math.max(30, autoRefreshSecs) * 1000;
+    const timer = setInterval(() => onTick(), ms);
+    return () => clearInterval(timer);
+  }, [autoRefresh, autoRefreshSecs, onTick]);
+
+  return {
+    autoRefresh,
+    setAutoRefresh,
+    autoRefreshSecs,
+    setAutoRefreshSecs,
+    toggleAutoRefresh,
+  };
+}

--- a/desktop/frontend/src/useDrafts.ts
+++ b/desktop/frontend/src/useDrafts.ts
@@ -1,0 +1,79 @@
+import { useCallback, useState, type Dispatch, type SetStateAction } from "react";
+import { backend, type DraftSummary, type MessageDetail } from "./api";
+import type { ComposeInit } from "./Compose";
+
+// useDrafts owns the drafts subsystem: the drafts list, whether the left pane is
+// showing drafts, and the load/open actions. Extracted from App.tsx unchanged.
+// Opening a draft hands a ComposeInit to App's compose state; entering the
+// drafts view clears the open message. Those cross-subsystem setters are passed
+// in as deps.
+export interface Drafts {
+  draftsView: boolean;
+  setDraftsView: Dispatch<SetStateAction<boolean>>;
+  drafts: DraftSummary[];
+  loadingDrafts: boolean;
+  loadDrafts: () => Promise<void>;
+  openDrafts: () => void;
+  openDraft: (d: DraftSummary) => Promise<void>;
+}
+
+export function useDrafts(deps: {
+  setError: (e: string) => void;
+  setSelectedId: Dispatch<SetStateAction<string | null>>;
+  setDetail: Dispatch<SetStateAction<MessageDetail | null>>;
+  setCompose: Dispatch<SetStateAction<ComposeInit | null>>;
+}): Drafts {
+  const { setError, setSelectedId, setDetail, setCompose } = deps;
+  const [draftsView, setDraftsView] = useState(false);
+  const [drafts, setDrafts] = useState<DraftSummary[]>([]);
+  const [loadingDrafts, setLoadingDrafts] = useState(false);
+
+  const loadDrafts = useCallback(async () => {
+    setLoadingDrafts(true);
+    setError("");
+    try {
+      setDrafts(await backend.ListDrafts());
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoadingDrafts(false);
+    }
+  }, [setError]);
+
+  const openDrafts = useCallback(() => {
+    setDraftsView(true);
+    setSelectedId(null);
+    setDetail(null);
+    void loadDrafts();
+  }, [loadDrafts, setSelectedId, setDetail]);
+
+  const openDraft = useCallback(
+    async (d: DraftSummary) => {
+      setError("");
+      try {
+        const det = await backend.GetDraft(d.id);
+        setCompose({
+          mode: "draft",
+          draftId: det.id,
+          to: det.to,
+          cc: det.cc,
+          subject: det.subject,
+          body: det.body,
+        });
+      } catch (e) {
+        setError(String(e));
+      }
+    },
+    [setError, setCompose],
+  );
+
+  return {
+    draftsView,
+    setDraftsView,
+    drafts,
+    loadingDrafts,
+    loadDrafts,
+    openDrafts,
+    openDraft,
+  };
+}

--- a/desktop/frontend/src/useIntegrations.ts
+++ b/desktop/frontend/src/useIntegrations.ts
@@ -1,0 +1,52 @@
+import { useCallback, useState } from "react";
+import { backend } from "./api";
+
+// useIntegrations owns the optional outbound integrations (Obsidian, Slack):
+// whether each is enabled (from backend config) and the fire-and-forget send
+// actions. Extracted from App.tsx unchanged. Call refresh() during init to pull
+// the enabled flags.
+export interface Integrations {
+  obsidianOn: boolean;
+  slackOn: boolean;
+  refresh: () => Promise<void>;
+  sendObsidian: (id: string) => void;
+  forwardSlack: (id: string) => void;
+}
+
+export function useIntegrations(deps: {
+  showToast: (m: string) => void;
+  setError: (e: string) => void;
+}): Integrations {
+  const { showToast, setError } = deps;
+  const [obsidianOn, setObsidianOn] = useState(false);
+  const [slackOn, setSlackOn] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setObsidianOn(await backend.ObsidianEnabled());
+    setSlackOn(await backend.SlackEnabled());
+  }, []);
+
+  const sendObsidian = useCallback(
+    (id: string) => {
+      showToast("Sending to Obsidian…");
+      void backend
+        .SendToObsidian(id)
+        .then((p) => showToast(p ? `Saved to Obsidian: ${p}` : "Saved to Obsidian"))
+        .catch((e) => setError(String(e)));
+    },
+    [showToast, setError],
+  );
+
+  const forwardSlack = useCallback(
+    (id: string) => {
+      showToast("Forwarding to Slack…");
+      void backend
+        .ForwardToSlack(id)
+        .then(() => showToast("Forwarded to Slack"))
+        .catch((e) => setError(String(e)));
+    },
+    [showToast, setError],
+  );
+
+  return { obsidianOn, slackOn, refresh, sendObsidian, forwardSlack };
+}

--- a/desktop/frontend/src/useUndo.ts
+++ b/desktop/frontend/src/useUndo.ts
@@ -1,0 +1,50 @@
+import { useCallback, useRef, useState } from "react";
+
+// useUndo owns the undo stack: a bounded LIFO of {label, run} entries. Handlers
+// (archive/trash/move/…) push a reversal closure; U (or the topbar button) runs
+// the most recent. Extracted from App.tsx unchanged — the stack lives in a ref
+// so pushing never re-renders, and undoLabel drives the button label.
+export interface Undo {
+  undoLabel: string;
+  pushUndo: (label: string, run: () => Promise<void>) => void;
+  runUndo: () => Promise<void>;
+}
+
+export function useUndo(deps: {
+  showToast: (m: string) => void;
+  setError: (e: string) => void;
+}): Undo {
+  const { showToast, setError } = deps;
+  const undoRef = useRef<{ label: string; run: () => Promise<void> }[]>([]);
+  const [undoLabel, setUndoLabel] = useState("");
+
+  const pushUndo = useCallback(
+    (label: string, run: () => Promise<void>) => {
+      undoRef.current.push({ label, run });
+      if (undoRef.current.length > 25) undoRef.current.shift();
+      setUndoLabel(label);
+    },
+    [],
+  );
+
+  const runUndo = useCallback(async () => {
+    const entry = undoRef.current.pop();
+    setUndoLabel(
+      undoRef.current.length
+        ? undoRef.current[undoRef.current.length - 1].label
+        : "",
+    );
+    if (!entry) {
+      showToast("Nothing to undo");
+      return;
+    }
+    try {
+      await entry.run();
+      showToast(`Undone: ${entry.label}`);
+    } catch (e) {
+      setError(String(e));
+    }
+  }, [showToast, setError]);
+
+  return { undoLabel, pushUndo, runUndo };
+}

--- a/docs/DESKTOP_REFACTOR_PLAN.md
+++ b/docs/DESKTOP_REFACTOR_PLAN.md
@@ -207,8 +207,8 @@ the state+handlers must move into **subsystem hooks** (the risky decoupling — 
 §3 landmines first: `openIdRef`, `aiCache`, mirror refs, `loadMessage` reset order).
 
 Proposed hook sequence (each its own PR, e2e-guarded, safest → riskiest):
-- `useUndo`, `useAutoRefresh`, `useIntegrations` (obsidian/slack) — small, isolated
-- `useDrafts`, `useCompose` — self-contained
+- [x] **F5.1** `useUndo` (50) + `useIntegrations` (52) + `useAutoRefresh` (47) + `useDrafts` (79) — small, isolated; App.tsx 4,109 → 4,023; +1 e2e (`drafts.spec.ts`); unit 61 / e2e 34
+- `useCompose` — self-contained
 - `useAccounts` (switch/list) — isolated
 - `useBulk` (bulkAction/toggleSelect/exitBulk/select-all)
 - `useSearch` (query/localFilter/load/loadMore/pending/prune) — touches `fullMessagesRef`


### PR DESCRIPTION
## 📋 **Description**

First step of the subsystem-hook phase toward the **no-file-over-400** target. Moves four **isolated, self-contained** subsystems out of `App.tsx` into hooks:

- `useUndo` (50) — the undo stack + `pushUndo`/`runUndo`
- `useIntegrations` (52) — Obsidian/Slack enabled flags + send actions
- `useAutoRefresh` (47) — poll toggle + interval effect (the poll, `checkNewMail`, stays in App and is passed as `onTick`)
- `useDrafts` (79) — drafts list/view + load/open

Behavior-preserving: App calls the hooks and passes the cross-subsystem setters they depend on. `App.tsx` **4,109 → 4,023**.

> **Honest note on what's left:** these were the cleanly-isolated subsystems. The remaining state in App (`switchAccount`, `bulkAction`, message-list, AI panels) is coupled orchestration — reaching App < 400 needs the bigger `useMessages` / `useAi` hooks, each a larger, e2e-guarded PR. Tracked in `docs/DESKTOP_REFACTOR_PLAN.md` §7bis.

## 🧪 **Testing**
- [x] `npm test` (vitest): 61 passed
- [x] `npm run test:e2e` (Playwright): 34 passed — new `drafts.spec.ts` guards the drafts flow the hook now owns
- [x] `npx tsc --noEmit` + `npm run build` clean

## 📝 **Related Issues**
Part of the `App.tsx` decomposition tracked in `docs/DESKTOP_REFACTOR_PLAN.md` (F5.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU)_