### PR TITLE
feat(star): first-class star / unstar for messages (TUI & desktop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ All platforms include:
 ## 🆘 Need Help?
 
 - **[Getting Started Guide](docs/GETTING_STARTED.md)** - Setup and first steps
+- **[Troubleshooting](docs/TROUBLESHOOTING.md)** - Fixes for common problems (auth, rendering, loading)
 - **[Known Issues](docs/KNOWN_ISSUES.md)** - Common problems and solutions
 - **[GitHub Issues](https://github.com/ajramos/giztui/issues)** - Bug reports and feature requests
 - **[GitHub Discussions](https://github.com/ajramos/giztui/discussions)** - Community support

--- a/desktop/app_mail.go
+++ b/desktop/app_mail.go
@@ -106,6 +106,24 @@ func (a *App) MarkUnread(id string) error {
 	return api.MarkUnread(a.ctx, id)
 }
 
+// Star adds the STARRED label to a message.
+func (a *App) Star(id string) error {
+	api, err := a.api()
+	if err != nil {
+		return err
+	}
+	return api.Star(a.ctx, id)
+}
+
+// Unstar removes the STARRED label from a message.
+func (a *App) Unstar(id string) error {
+	api, err := a.api()
+	if err != nil {
+		return err
+	}
+	return api.Unstar(a.ctx, id)
+}
+
 // ListLabels returns the account's labels.
 func (a *App) ListLabels() ([]desktop.Label, error) {
 	api, err := a.api()

--- a/desktop/frontend/e2e/star.spec.ts
+++ b/desktop/frontend/e2e/star.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+import { openApp, openMessageAt, rows, runCommand } from "./helpers";
+
+// Star / unstar (issue #34). '*' toggles the STARRED flag on the highlighted
+// message and the row shows a .star-flag indicator, reflected in place (no
+// refetch). ':star' / ':unstar' commands do the same on the open message.
+// Mock message 0 starts unstarred (see apiMockData: starred = i % 4 === 1).
+test.describe("star", () => {
+  test("'*' toggles the star indicator on the open message", async ({ page }) => {
+    await openApp(page);
+    await openMessageAt(page, 0);
+    const row0 = rows(page).nth(0);
+    await expect(row0.locator(".star-flag")).toHaveCount(0);
+    await page.keyboard.press("*");
+    await expect(row0.locator(".star-flag")).toBeVisible();
+    await page.keyboard.press("*");
+    await expect(row0.locator(".star-flag")).toHaveCount(0);
+  });
+
+  test("':star' and ':unstar' flip the open message", async ({ page }) => {
+    await openApp(page);
+    await openMessageAt(page, 0);
+    const row0 = rows(page).nth(0);
+    await runCommand(page, "star");
+    await expect(row0.locator(".star-flag")).toBeVisible();
+    await runCommand(page, "unstar");
+    await expect(row0.locator(".star-flag")).toHaveCount(0);
+  });
+});

--- a/desktop/frontend/e2e/star.spec.ts
+++ b/desktop/frontend/e2e/star.spec.ts
@@ -26,4 +26,14 @@ test.describe("star", () => {
     await runCommand(page, "unstar");
     await expect(row0.locator(".star-flag")).toHaveCount(0);
   });
+
+  test("':star' stars the whole selection in bulk mode", async ({ page }) => {
+    await openApp(page);
+    // ':select all' enters bulk mode with every row selected; ':star' then stars
+    // the whole selection (bulk-aware command), so every row shows the indicator.
+    await runCommand(page, "select all");
+    await runCommand(page, "star");
+    const total = await rows(page).count();
+    await expect(rows(page).locator(".star-flag")).toHaveCount(total);
+  });
 });

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -362,6 +362,7 @@ export default function App() {
     insertMessage,
     applyLabelChange,
     doAction,
+    toggleStar,
     toggleSelect,
     exitBulk,
     clearReaderIfRemoved,
@@ -438,7 +439,7 @@ export default function App() {
     setQuery, setReaderFocused, setRsvpPickerOpen, setRulesOpen, setSaveQueryOpen, setSelected, setSelectedId,
     setShowHelp, setStatsOpen, setSuggestFor, setThemePickerOpen, setTouchUpText, setViewHtml, setZoom,
     showHelp, showToast, slackOn, statsOpen, suggestFor, summarize, summarizeThread,
-    themePickerOpen, themesOn, threadMsgs, threadingOn, toggleAutoRefresh, toggleSelect, toggleThread,
+    themePickerOpen, themesOn, threadMsgs, threadingOn, toggleAutoRefresh, toggleSelect, toggleStar, toggleThread,
     toggleToolbar, touchUp, touchUpText, viewAnalyzerPrompt, vimRange,
   });
 

--- a/desktop/frontend/src/Help.tsx
+++ b/desktop/frontend/src/Help.tsx
@@ -40,6 +40,7 @@ function buildSections(k: KeyMap, f: HelpFlags): Section[] {
       { icon: "📁", keys: fmtKey(k.archive), desc: "Archive" },
       { icon: "🗑️", keys: fmtKey(k.trash), desc: "Move to trash" },
       { icon: "👁️", keys: `${fmtKey(k.toggleRead)} · :t`, desc: "Toggle read / unread (:read · :markunread)" },
+      { icon: "⭐", keys: "* · :star", desc: "Star / unstar message (:star · :unstar)" },
       { icon: "↩️", keys: fmtKey(k.undo), desc: "Undo last action" },
       { icon: "📦", keys: fmtKey(k.move), desc: "Move to folder" },
       { icon: "🔖", keys: fmtKey(k.manageLabels), desc: "Manage labels" },

--- a/desktop/frontend/src/Icons.tsx
+++ b/desktop/frontend/src/Icons.tsx
@@ -19,6 +19,12 @@ const svg = (children: ReactNode) => (
 
 export const Icon = {
   chat: svg(<path d="M21 11.5a8.38 8.38 0 0 1-8.5 8.5 8.5 8.5 0 0 1-3.8-.9L3 21l1.9-5.7a8.5 8.5 0 0 1-.9-3.8A8.38 8.38 0 0 1 12.5 3a8.38 8.38 0 0 1 8.5 8.5z" />),
+  // Filled star for the "starred" list indicator (fill, not stroke).
+  star: (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+    </svg>
+  ),
   send: svg(
     <>
       <line x1="22" y1="2" x2="11" y2="13" />

--- a/desktop/frontend/src/MessageList.tsx
+++ b/desktop/frontend/src/MessageList.tsx
@@ -226,6 +226,11 @@ export default function MessageList({
                         </span>
                       )}
                       <span className="from">{displayName(m.from)}</span>
+                      {m.starred && (
+                        <span className="star-flag" title="Starred">
+                          {Icon.star}
+                        </span>
+                      )}
                       <span className="date">{formatDate(m.date)}</span>
                     </div>
                     <div className="subject">{m.subject || "(no subject)"}</div>

--- a/desktop/frontend/src/apiMockA.ts
+++ b/desktop/frontend/src/apiMockA.ts
@@ -66,6 +66,8 @@ export const mockA: Partial<Backend> = {
   async Trash() {},
   async MarkRead() {},
   async MarkUnread() {},
+  async Star() {},
+  async Unstar() {},
   async Unarchive() {},
   async Untrash() {},
   async BulkUnarchive() {},
@@ -259,6 +261,7 @@ export const mockA: Partial<Backend> = {
       cc: "",
       date: new Date(Date.now() - (3 - i) * 3600_000).toISOString(),
       unread,
+      starred: false,
       labels: ["Work"],
       plainText:
         i === 0

--- a/desktop/frontend/src/apiMockData.ts
+++ b/desktop/frontend/src/apiMockData.ts
@@ -34,6 +34,7 @@ export const mockMessages: MessageSummary[] = Array.from({ length: 24 }, (_, i) 
     "This is a preview of the message body shown in the inbox list so you can scan quickly…",
   date: new Date(Date.now() - i * 3600_000).toISOString(),
   unread: i % 3 === 0,
+  starred: i % 4 === 1,
   labels: i % 4 === 0 ? ["Work"] : i % 5 === 0 ? ["Personal", "Travel"] : [],
 }));
 

--- a/desktop/frontend/src/apiTypes.ts
+++ b/desktop/frontend/src/apiTypes.ts
@@ -17,6 +17,7 @@ export interface MessageSummary {
   snippet: string;
   date: string;
   unread: boolean;
+  starred: boolean;
   labels: string[];
 }
 
@@ -29,6 +30,7 @@ export interface MessageDetail {
   cc: string;
   date: string;
   unread: boolean;
+  starred: boolean;
   labels: string[];
   plainText: string;
   html: string;
@@ -311,6 +313,8 @@ export interface Backend {
   Trash(id: string): Promise<void>;
   MarkRead(id: string): Promise<void>;
   MarkUnread(id: string): Promise<void>;
+  Star(id: string): Promise<void>;
+  Unstar(id: string): Promise<void>;
   Unarchive(id: string): Promise<void>;
   Untrash(id: string): Promise<void>;
   BulkUnarchive(ids: string[]): Promise<void>;

--- a/desktop/frontend/src/commandCtx.ts
+++ b/desktop/frontend/src/commandCtx.ts
@@ -15,6 +15,7 @@ export interface CommandCtx {
   detail: MessageDetail | null;
   load: (q: string) => Promise<void>;
   doAction: (action: "archive" | "trash" | "read" | "unread" | "star" | "unstar", id: string) => Promise<void>;
+  bulkAction: (action: "archive" | "trash" | "read" | "unread" | "star" | "unstar") => Promise<void>;
   activeQuery: string;
   openDrafts: () => void;
   saveMessage: (id: string) => void;

--- a/desktop/frontend/src/commandCtx.ts
+++ b/desktop/frontend/src/commandCtx.ts
@@ -14,7 +14,7 @@ import type { ComposeInit } from "./Compose";
 export interface CommandCtx {
   detail: MessageDetail | null;
   load: (q: string) => Promise<void>;
-  doAction: (action: "archive" | "trash" | "read" | "unread", id: string) => Promise<void>;
+  doAction: (action: "archive" | "trash" | "read" | "unread" | "star" | "unstar", id: string) => Promise<void>;
   activeQuery: string;
   openDrafts: () => void;
   saveMessage: (id: string) => void;

--- a/desktop/frontend/src/commandRunner.ts
+++ b/desktop/frontend/src/commandRunner.ts
@@ -11,7 +11,7 @@ export function runCommand(input: string, ctx: CommandCtx) {
     detail, load, doAction, activeQuery, openDrafts, saveMessage,
     openObsidian, openSlackForward, obsidianOn, slackOn, aiEnabled, aiPromptsEnabled,
     summarize, openChat, openSuggest, openInGmail, openQueries, savedQueriesOn, runActionPlan,
-    runDeterministicRules, actionPlanOn, bulkMode, selected, showToast, doMove,
+    runDeterministicRules, actionPlanOn, bulkMode, selected, bulkAction, showToast, doMove,
     doBulkMove, generateReply, quickSearch, themesOn, applyTheme, rulesEnabled,
     openRules, viewAnalyzerPrompt, toggleToolbar, touchUp, touchUpText, localFilter,
     applyLocalFilter, query, runUndo, toggleAutoRefresh, saveRawMessage, invite,
@@ -79,11 +79,13 @@ export function runCommand(input: string, ctx: CommandCtx) {
           break;
         case "star":
         case "st":
-          if (d) void doAction("star", d.id);
+          if (bulkMode && selected.size > 0) void bulkAction("star");
+          else if (d) void doAction("star", d.id);
           break;
         case "unstar":
         case "unst":
-          if (d) void doAction("unstar", d.id);
+          if (bulkMode && selected.size > 0) void bulkAction("unstar");
+          else if (d) void doAction("unstar", d.id);
           break;
         case "labels":
         case "l":

--- a/desktop/frontend/src/commandRunner.ts
+++ b/desktop/frontend/src/commandRunner.ts
@@ -77,6 +77,14 @@ export function runCommand(input: string, ctx: CommandCtx) {
             void doAction(cur?.unread ? "read" : "unread", d.id);
           }
           break;
+        case "star":
+        case "st":
+          if (d) void doAction("star", d.id);
+          break;
+        case "unstar":
+        case "unst":
+          if (d) void doAction("unstar", d.id);
+          break;
         case "labels":
         case "l":
           if (d) setLabelsFor(d.id);

--- a/desktop/frontend/src/commands.ts
+++ b/desktop/frontend/src/commands.ts
@@ -60,6 +60,8 @@ export const COMMANDS: CommandDef[] = [
   { names: ["read"], desc: "Mark read" },
   { names: ["markunread"], desc: "Mark unread" },
   { names: ["toggle-read", "t"], desc: "Toggle read / unread" },
+  { names: ["star", "st"], desc: "Star message" },
+  { names: ["unstar", "unst"], desc: "Unstar message" },
   { names: ["labels", "l"], desc: "Manage labels" },
   { names: ["compose", "c", "new"], desc: "New message" },
   { names: ["reply", "r"], desc: "Reply" },

--- a/desktop/frontend/src/format.ts
+++ b/desktop/frontend/src/format.ts
@@ -41,6 +41,10 @@ export function labelForAction(action: string): string {
       return "Marking read";
     case "unread":
       return "Marking unread";
+    case "star":
+      return "Starring";
+    case "unstar":
+      return "Unstarring";
     default:
       return "Working on";
   }

--- a/desktop/frontend/src/keydownCtx.ts
+++ b/desktop/frontend/src/keydownCtx.ts
@@ -153,6 +153,7 @@ export interface KeydownCtx {
   themePickerOpen: boolean;
   threadingOn: boolean;
   toggleSelect: (id: string) => void;
+  toggleStar: (id: string) => Promise<void>;
   toggleThread: () => Promise<void>;
   viewAnalyzerPrompt: () => Promise<void>;
 }

--- a/desktop/frontend/src/keydownCtx.ts
+++ b/desktop/frontend/src/keydownCtx.ts
@@ -28,7 +28,7 @@ export interface KeydownCtx {
   aiPromptsEnabled: boolean;
   applyCategory: (cat: PlanCategory, asMove?: boolean) => Promise<void>;
   attachments: Attachment[];
-  bulkAction: (action: "archive" | "trash" | "read" | "unread") => Promise<void>;
+  bulkAction: (action: "archive" | "trash" | "read" | "unread" | "star" | "unstar") => Promise<void>;
   bulkLabels: boolean;
   bulkMode: boolean;
   bulkMove: boolean;

--- a/desktop/frontend/src/keydownMain.ts
+++ b/desktop/frontend/src/keydownMain.ts
@@ -19,7 +19,7 @@ export function handleKeyMain(e: KeyboardEvent, ctx: KeydownCtx) {
     setHeadersHidden, setLabelsFor, setLinksFor, setLocalFilter, setMessages, setMoveFor,
     setPromptsOpen, setQuery, setReaderFocused, setRsvpPickerOpen, setJobsPickerOpen, openChat, setSaveQueryOpen, setSelected,
     setSelectedId, setShowHelp, setThemePickerOpen, setViewHtml, showToast, slackOn,
-    summarize, threadingOn, toggleSelect, toggleThread,
+    summarize, threadingOn, toggleSelect, toggleStar, toggleThread,
     activeQuery, gPressedAt, vimRange, openSlackForward, themesOn,
   } = ctx;
       const chord = e.key === " " ? "space" : e.key;
@@ -175,9 +175,14 @@ export function handleKeyMain(e: KeyboardEvent, ctx: KeydownCtx) {
         return;
       }
       if (chord === "*") {
+        e.preventDefault();
         if (bulkMode) {
-          e.preventDefault();
+          // Bulk mode: select all (TUI parity).
           setSelected(new Set(messages.map((m) => m.id)));
+        } else {
+          // Otherwise toggle the star on the highlighted / open message.
+          const id = selectedId ?? detail?.id;
+          if (id) void toggleStar(id);
         }
         return;
       }

--- a/desktop/frontend/src/styles/01-base.css
+++ b/desktop/frontend/src/styles/01-base.css
@@ -277,6 +277,16 @@ button.danger {
   gap: 8px;
   margin-bottom: 2px;
 }
+.star-flag {
+  display: inline-flex;
+  align-items: center;
+  color: #e6b800;
+  flex: 0 0 auto;
+}
+.star-flag svg {
+  width: 13px;
+  height: 13px;
+}
 .row .from {
   font-weight: 600;
   overflow: hidden;

--- a/desktop/frontend/src/useMailActions.ts
+++ b/desktop/frontend/src/useMailActions.ts
@@ -19,13 +19,14 @@ export interface MailActions {
   removeFromList: (id: string) => void;
   insertMessage: (msg: MessageSummary, index: number) => void;
   applyLabelChange: (ids: Set<string>, change: { added?: string; removed?: string }) => void;
-  doAction: (action: "archive" | "trash" | "read" | "unread", id: string) => Promise<void>;
+  doAction: (action: "archive" | "trash" | "read" | "unread" | "star" | "unstar", id: string) => Promise<void>;
+  toggleStar: (id: string) => Promise<void>;
   toggleSelect: (id: string) => void;
   exitBulk: () => void;
   clearReaderIfRemoved: (removed: Set<string>) => void;
   advanceAfterBulk: (removed: Set<string>) => void;
-  bulkActionIds: (action: "archive" | "trash" | "read" | "unread", ids: string[]) => Promise<void>;
-  bulkAction: (action: "archive" | "trash" | "read" | "unread") => Promise<void>;
+  bulkActionIds: (action: "archive" | "trash" | "read" | "unread" | "star" | "unstar", ids: string[]) => Promise<void>;
+  bulkAction: (action: "archive" | "trash" | "read" | "unread" | "star" | "unstar") => Promise<void>;
 }
 
 export function useMailActions(deps: {
@@ -91,7 +92,7 @@ export function useMailActions(deps: {
   }, []);
 
   const doAction = useCallback(
-    async (action: "archive" | "trash" | "read" | "unread", id: string) => {
+    async (action: "archive" | "trash" | "read" | "unread" | "star" | "unstar", id: string) => {
       const msg = messages.find((m) => m.id === id);
       const index = messages.findIndex((m) => m.id === id);
       setBusy(true);
@@ -141,6 +142,20 @@ export function useMailActions(deps: {
             );
             setDetail((d) => (d && d.id === id ? { ...d, unread: false } : d));
           });
+        } else if (action === "star") {
+          await backend.Star(id);
+          setMessages((prev) =>
+            prev.map((x) => (x.id === id ? { ...x, starred: true } : x)),
+          );
+          setDetail((d) => (d && d.id === id ? { ...d, starred: true } : d));
+          showToast("Starred");
+        } else if (action === "unstar") {
+          await backend.Unstar(id);
+          setMessages((prev) =>
+            prev.map((x) => (x.id === id ? { ...x, starred: false } : x)),
+          );
+          setDetail((d) => (d && d.id === id ? { ...d, starred: false } : d));
+          showToast("Star removed");
         }
       } catch (e) {
         setError(String(e));
@@ -149,6 +164,16 @@ export function useMailActions(deps: {
       }
     },
     [messages, removeFromList, showToast, pushUndo, insertMessage],
+  );
+
+  // toggleStar flips the STARRED label on a single message, reading the current
+  // state from the list so it doesn't need an extra fetch.
+  const toggleStar = useCallback(
+    async (id: string) => {
+      const cur = messages.find((m) => m.id === id)?.starred ?? false;
+      await doAction(cur ? "unstar" : "star", id);
+    },
+    [messages, doAction],
   );
 
   // applyLabelChange updates the label chips of the affected messages (in the
@@ -256,7 +281,7 @@ export function useMailActions(deps: {
   // It does NOT touch the `selected` set — callers decide whether to clear it.
   const bulkActionIds = useCallback(
     async (
-      action: "archive" | "trash" | "read" | "unread",
+      action: "archive" | "trash" | "read" | "unread" | "star" | "unstar",
       ids: string[],
     ) => {
       if (ids.length === 0) return;
@@ -299,6 +324,18 @@ export function useMailActions(deps: {
             prev.map((m) => (idSet.has(m.id) ? { ...m, unread: true } : m)),
           );
           showToast(`Marked ${ids.length} unread`);
+        } else if (action === "star") {
+          await backend.BulkApplyLabel(ids, "STARRED");
+          setMessages((prev) =>
+            prev.map((m) => (idSet.has(m.id) ? { ...m, starred: true } : m)),
+          );
+          showToast(`Starred ${ids.length}`);
+        } else if (action === "unstar") {
+          await backend.BulkRemoveLabel(ids, "STARRED");
+          setMessages((prev) =>
+            prev.map((m) => (idSet.has(m.id) ? { ...m, starred: false } : m)),
+          );
+          showToast(`Unstarred ${ids.length}`);
         }
       } catch (e) {
         setError(String(e));
@@ -311,7 +348,7 @@ export function useMailActions(deps: {
   );
 
   const bulkAction = useCallback(
-    async (action: "archive" | "trash" | "read" | "unread") => {
+    async (action: "archive" | "trash" | "read" | "unread" | "star" | "unstar") => {
       const ids = [...selected];
       if (ids.length === 0) return;
       await bulkActionIds(action, ids);
@@ -325,6 +362,7 @@ export function useMailActions(deps: {
     insertMessage,
     applyLabelChange,
     doAction,
+    toggleStar,
     toggleSelect,
     exitBulk,
     clearReaderIfRemoved,

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -287,6 +287,9 @@ Now that you're up and running:
 3. **Master Shortcuts**: Review [KEYBOARD_SHORTCUTS.md](KEYBOARD_SHORTCUTS.md) for efficiency
 4. **Advanced Usage**: Try integrations like Slack forwarding and Obsidian note-taking
 
+> Hit a snag? The [Troubleshooting guide](TROUBLESHOOTING.md) covers the common
+> auth, rendering, and loading problems (and how to grab your log for a report).
+
 ## 🔗 Quick Reference
 
 **Essential Shortcuts:**

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,168 @@
+# 🆘 Troubleshooting GizTUI
+
+A practical guide to the problems people actually hit, with the fix for each.
+If something here doesn't match what you see, grab your log (see below) and open
+an issue — [How to report a bug](#-how-to-report-a-bug) tells you what to include.
+
+> This is the **user-facing** guide. Developers tracking known internal defects
+> should see [KNOWN_ISSUES.md](KNOWN_ISSUES.md) instead.
+
+## 📂 Where things live
+
+Everything lives under `~/.config/giztui/`:
+
+| File | What it is |
+|------|-----------|
+| `config.json` | Your configuration (keys, theme, LLM, integrations) |
+| `credentials.json` | Google OAuth **client** credentials (you download these) |
+| `token.json` | The OAuth **token** minted after you authorize (auto-created) |
+| `giztui.log` | The TUI log — the first thing to check when something misbehaves |
+| `desktop.log` | The desktop app log (GizTUI Desktop only) |
+
+Useful commands:
+
+```bash
+giztui --version          # exact version / commit (include this in bug reports)
+giztui --setup            # re-run the interactive setup wizard
+giztui --migrate-config   # add any new default config keys to your config.json
+tail -f ~/.config/giztui/giztui.log   # watch the log live while reproducing
+```
+
+Inside the app: `?` opens help, `:config` shows the active configuration.
+
+---
+
+## 🔑 Credentials & authentication
+
+### "Credentials not found"
+GizTUI can't find your OAuth **client** file. Fix, in order:
+
+1. Make sure the file is at `~/.config/giztui/credentials.json` (this is the file
+   you download from Google Cloud — see
+   [Gmail API Setup](GETTING_STARTED.md#gmail-api-setup)).
+2. Or point at it explicitly: `giztui --credentials /path/to/credentials.json`.
+3. Or set the environment variable `GMAIL_TUI_CREDENTIALS=/path/to/credentials.json`.
+4. Run `giztui --setup` to be walked through it.
+
+### "Access blocked: This app isn't verified"
+Your OAuth consent screen is in *testing* mode and your account isn't a test
+user. In the Google Cloud console → **APIs & Services → OAuth consent screen →
+Test users**, add the Gmail address you're logging in with. Then retry.
+
+### 403 `ACCESS_TOKEN_SCOPE_INSUFFICIENT` (or a feature says "insufficient scope")
+Your saved token was minted with fewer scopes than the feature needs (this often
+appears after upgrading, or when first using RSVP/calendar). Re-consent:
+
+```bash
+rm ~/.config/giztui/token.json
+giztui --setup            # or just relaunch — it re-opens the Google auth flow
+```
+
+You'll be asked to grant access again; the new token carries the full scope set.
+
+### 401 / "token expired or revoked" — auth loop on launch
+Same fix as above: delete `token.json` and re-authorize. This also resolves the
+case where you revoked GizTUI's access from your Google Account security page.
+
+### RSVP / calendar actions don't work
+Calendar access is a separate grant. Remove `~/.config/giztui/token.json` and
+re-authorize (`giztui --setup`) so the token includes calendar scope.
+
+---
+
+## 📥 Nothing loads / empty inbox
+
+- **Check the log** (`~/.config/giztui/giztui.log`) for an API error — it usually
+  names the cause (scope, quota, network).
+- **Wrong account?** If you use multiple accounts, confirm the active one
+  (`Ctrl+A` opens the account picker).
+- **Rate limit / quota (429):** wait a moment and press `R` to refresh.
+- **Network:** GizTUI needs outbound HTTPS to `googleapis.com`. Behind a proxy,
+  ensure `HTTPS_PROXY` is set in your shell.
+
+---
+
+## 🎨 Theme not loading / wrong colors
+
+- Run `:theme` to open the picker and pick a theme live; if the picker shows the
+  theme working, the issue is your config value.
+- In `config.json`, the theme is referenced **by name** (e.g. `"gmail-dark"`),
+  not by path. A typo falls back to the default theme.
+- Custom themes must be valid JSON in the themes directory; an invalid file is
+  skipped (check the log for a parse warning).
+- Colors look flat/washed out? Your terminal needs **256-color** (or truecolor)
+  support — see terminal rendering below.
+
+---
+
+## 🖥️ Terminal rendering (misaligned columns, broken emoji)
+
+GizTUI is a TUI; a few issues are the terminal, not the app:
+
+- **Columns look shifted / an emoji "eats" a character.** Some glyphs are
+  *East-Asian-Wide* and render two cells wide in some terminals and one in
+  others. Use a terminal with correct Unicode width handling (recent
+  iTerm2/WezTerm/Kitty/Windows Terminal) and a font with good emoji coverage.
+- **Boxes/borders look wrong.** Ensure `TERM` advertises 256 colors
+  (`echo $TERM` → something like `xterm-256color`).
+- **Everything is monochrome.** Your terminal or multiplexer is stripping colors;
+  in tmux set `set -g default-terminal "tmux-256color"`.
+
+---
+
+## ✅ Bulk mode & selection
+
+- Enter bulk mode with `v` (or `b`); the status bar shows the bulk hint.
+- `Space` toggles the current row; `*` selects/clears **all**; `Esc` exits bulk.
+- Actions in bulk apply to the whole selection: `a` archive, `d` trash, `m` move,
+  `l` labels, `:star` star, `p` prompt.
+- If the status bar looks "stuck" after a bulk action, press `Esc` to exit bulk
+  mode and refresh.
+
+---
+
+## 🔄 Auto-refresh / new-mail not updating
+
+- Auto-refresh is **opt-in**. Toggle it in-app or set it in `config.json`; the
+  setting now persists across restarts.
+- If it seems off despite the config saying on, relaunch — startup reads the
+  config as the source of truth.
+
+---
+
+## 🧩 Missing options after an upgrade
+
+New releases add config keys. If a new feature seems absent or a new shortcut
+does nothing, your `config.json` predates it. Pull in the new defaults:
+
+```bash
+giztui --migrate-config       # or :config migrate inside the app
+```
+
+Your existing settings are preserved; only missing keys are added.
+
+---
+
+## 🍏 GizTUI Desktop (Wails app)
+
+- **Remote images don't show.** By design, remote images are **off** until you
+  load them (privacy); they're then fetched through the app's backend. Use the
+  load-images action in the reader.
+- **The window won't drag.** Drag from the top bar (it's the window drag region).
+- **A feature errors with "account email not set".** Switch/select an account so
+  account-scoped services (saved queries, rules, analyzer) initialize.
+- **Logs:** `~/.config/giztui/desktop.log`.
+
+---
+
+## 🐛 How to report a bug
+
+Open an issue at <https://github.com/ajramos/giztui/issues> with:
+
+1. **Version:** output of `giztui --version`.
+2. **OS + terminal** (e.g. macOS 14 + WezTerm; or "GizTUI Desktop").
+3. **What you did** and **what happened** vs. what you expected.
+4. **A log snippet** from `~/.config/giztui/giztui.log` (or `desktop.log`) around
+   the moment it failed — redact any addresses/subjects you'd rather not share.
+
+The log is local-only and never uploaded by GizTUI; you choose what to include.

--- a/internal/render/email.go
+++ b/internal/render/email.go
@@ -342,6 +342,14 @@ func (er *EmailRenderer) extractMessageFlags(message *googleGmail.Message) strin
 		flags.WriteString("!")
 	}
 
+	// Starred indicator
+	for _, l := range message.LabelIds {
+		if l == "STARRED" {
+			flags.WriteString("★")
+			break
+		}
+	}
+
 	return flags.String()
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2224,6 +2224,7 @@ func (a *App) generateHelpText() string {
 	fmt.Fprintf(&help, "    %-8s  📁  Archive message\n", a.Keys.Archive)
 	fmt.Fprintf(&help, "    %-8s  🗑️   Move to trash\n", a.Keys.Trash)
 	fmt.Fprintf(&help, "    %-8s  👁️   Toggle read/unread\n", a.Keys.ToggleRead)
+	fmt.Fprintf(&help, "    %-8s  ⭐  Star / unstar message (:star / :unstar)\n", "*")
 	fmt.Fprintf(&help, "    %-8s  ↩️   Undo last action\n", a.Keys.Undo)
 	fmt.Fprintf(&help, "    %-8s  📦  Move message to folder\n", a.Keys.Move)
 	fmt.Fprintf(&help, "    %-8s  🔖  Manage labels\n", a.Keys.ManageLabels)

--- a/internal/tui/command_completion.go
+++ b/internal/tui/command_completion.go
@@ -123,6 +123,12 @@ var commandRegistry = []commandSpec{
 	{name: "read", aliases: []string{"toggle-read", "t"}, help: &cmdHelp{
 		summary: "Toggle the read/unread state of the current message (or selection).",
 	}},
+	{name: "star", aliases: []string{"st"}, help: &cmdHelp{
+		summary: "Star the current message (or selection). ':star toggle' flips it. Key: *",
+	}},
+	{name: "unstar", aliases: []string{"unst"}, help: &cmdHelp{
+		summary: "Remove the star from the current message (or the selected messages).",
+	}},
 	{name: "new"},
 	{name: "reply", aliases: []string{"r"}, help: &cmdHelp{
 		summary: "Reply to the sender of the current message.",

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -371,6 +371,10 @@ func (a *App) executeCommand(cmd string) {
 		a.executeTrashCommand(args)
 	case "read", "toggle-read", "t":
 		a.executeToggleReadCommand(args)
+	case "star", "st":
+		a.executeStarCommand(args)
+	case "unstar", "unst":
+		a.executeUnstarCommand(args)
 	case "new":
 		a.executeComposeCommand(args) // "new" as alias for compose
 	case "reply", "r":
@@ -1224,6 +1228,29 @@ func (a *App) executeToggleReadCommand(args []string) {
 		go a.toggleMarkReadUnreadBulk()
 	} else {
 		go a.toggleMarkReadUnread()
+	}
+}
+
+// executeStarCommand handles :star/:st commands. ":star toggle" flips the current
+// message; otherwise it stars the current message or the whole bulk selection.
+func (a *App) executeStarCommand(args []string) {
+	if len(args) > 0 && (args[0] == "toggle" || args[0] == "t") {
+		go a.toggleStar()
+		return
+	}
+	if a.bulk.isMode() && a.bulk.count() > 0 {
+		go a.starSelectedBulk(true)
+	} else {
+		go a.setStarCurrentMessage(true)
+	}
+}
+
+// executeUnstarCommand handles :unstar/:unst commands (current message or bulk).
+func (a *App) executeUnstarCommand(args []string) {
+	if a.bulk.isMode() && a.bulk.count() > 0 {
+		go a.starSelectedBulk(false)
+	} else {
+		go a.setStarCurrentMessage(false)
 	}
 }
 

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -903,6 +903,9 @@ func (a *App) bindKeys() {
 				}
 				return nil
 			}
+			// Non-bulk mode: '*' toggles the star on the selected message
+			go a.toggleStar()
+			return nil
 		case ':':
 			// Only handle if not configured as a configurable shortcut
 			if !a.isKeyConfigured(':') {

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -3765,6 +3765,77 @@ func (a *App) toggleMarkReadUnread() {
 	}(!isUnread)
 }
 
+// setStarCurrentMessage applies (star=true) or removes (star=false) the STARRED
+// label on the currently selected message, updating the cache and list in place.
+func (a *App) setStarCurrentMessage(star bool) {
+	messageIndex := a.getCurrentSelectedMessageIndex()
+	if messageIndex < 0 {
+		a.showError("❌ No message selected")
+		return
+	}
+	messageID := a.ids[messageIndex]
+	if messageID == "" {
+		a.showError("❌ Invalid message ID")
+		return
+	}
+	go func() {
+		// LabelService is the 3rd service returned by GetServices()
+		_, _, labelService, _, _, _, _, _, _, _, _, _ := a.GetServices()
+		var err error
+		if star {
+			err = labelService.ApplyLabel(a.ctx, messageID, "STARRED")
+		} else {
+			err = labelService.RemoveLabel(a.ctx, messageID, "STARRED")
+		}
+		if err != nil {
+			if star {
+				a.showError(fmt.Sprintf("❌ Error starring message: %v", err))
+			} else {
+				a.showError(fmt.Sprintf("❌ Error removing star: %v", err))
+			}
+			return
+		}
+		if star {
+			a.showStatusMessage("⭐ Message starred")
+		} else {
+			a.showStatusMessage("☆ Star removed")
+		}
+		a.QueueUpdateDraw(func() {
+			a.updateCachedMessageLabels(messageID, "STARRED", star)
+			a.refreshTableDisplay()
+		})
+	}()
+}
+
+// toggleStar flips the STARRED label on the currently selected message.
+func (a *App) toggleStar() {
+	messageIndex := a.getCurrentSelectedMessageIndex()
+	if messageIndex < 0 {
+		a.showError("❌ No message selected")
+		return
+	}
+	// Determine starred state from cache if possible to avoid an extra roundtrip
+	isStarred := false
+	if messageIndex < len(a.messagesMeta) && a.messagesMeta[messageIndex] != nil {
+		for _, l := range a.messagesMeta[messageIndex].LabelIds {
+			if l == "STARRED" {
+				isStarred = true
+				break
+			}
+		}
+	} else if messageID := a.ids[messageIndex]; messageID != "" {
+		if message, err := a.Client.GetMessage(messageID); err == nil {
+			for _, l := range message.LabelIds {
+				if l == "STARRED" {
+					isStarred = true
+					break
+				}
+			}
+		}
+	}
+	a.setStarCurrentMessage(!isStarred)
+}
+
 // listUnreadMessages searches for all unread messages using is:unread query
 func (a *App) listUnreadMessages() {
 	a.performSearch("is:unread")

--- a/internal/tui/messages_bulk.go
+++ b/internal/tui/messages_bulk.go
@@ -56,6 +56,60 @@ func (a *App) archiveSelectedBulk() {
 	}()
 }
 
+// starSelectedBulk applies (star=true) or removes (star=false) the STARRED label
+// on all selected messages. Unlike archive/trash, starred messages stay in the
+// list, so this refreshes labels in place rather than removing rows.
+func (a *App) starSelectedBulk(star bool) {
+	if a.bulk.count() == 0 {
+		return
+	}
+	ids := make([]string, 0, a.bulk.count())
+	ids = append(ids, a.bulk.ids()...)
+	verb := "Starring"
+	if !star {
+		verb = "Unstarring"
+	}
+	a.GetErrorHandler().ShowProgress(a.ctx, fmt.Sprintf("%s %d message(s)…", verb, len(ids)))
+	go func() {
+		// LabelService is the 3rd service returned by GetServices()
+		_, _, labelService, _, _, _, _, _, _, _, _, _ := a.GetServices()
+		var err error
+		if star {
+			err = labelService.BulkApplyLabel(a.ctx, ids, "STARRED", a.bulkProgress(a.ctx, verb))
+		} else {
+			err = labelService.BulkRemoveLabel(a.ctx, ids, "STARRED")
+		}
+		a.GetErrorHandler().ClearPersistentMessage()
+
+		a.QueueUpdateDraw(func() {
+			for _, id := range ids {
+				a.updateCachedMessageLabels(id, "STARRED", star)
+			}
+			// Exit bulk mode and restore normal rendering/styles
+			a.bulk.clear()
+			a.bulk.setMode(false)
+			a.refreshTableDisplay()
+			if list, ok := a.views["list"].(*tview.Table); ok {
+				list.SetSelectedStyle(a.getSelectionStyle())
+			}
+			a.focusList()
+		})
+
+		// ErrorHandler calls outside QueueUpdateDraw to avoid deadlock
+		a.GetErrorHandler().ClearProgress()
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			if err != nil {
+				a.GetErrorHandler().ShowWarning(a.ctx, fmt.Sprintf("%s completed with error: %v", verb, err))
+			} else if star {
+				a.GetErrorHandler().ShowSuccess(a.ctx, "Starred")
+			} else {
+				a.GetErrorHandler().ShowSuccess(a.ctx, "Unstarred")
+			}
+		}()
+	}()
+}
+
 // trashSelectedBulk moves all selected messages to trash
 func (a *App) trashSelectedBulk() {
 	if a.bulk.count() == 0 {

--- a/pkg/desktop/api.go
+++ b/pkg/desktop/api.go
@@ -230,6 +230,7 @@ func (a *API) GetMessage(ctx context.Context, id string) (*MessageDetail, error)
 		detail.ID = msg.Id
 		detail.ThreadID = msg.ThreadId
 		detail.Unread = containsLabel(msg.LabelIds, "UNREAD")
+		detail.Starred = containsLabel(msg.LabelIds, "STARRED")
 	}
 	return detail, nil
 }
@@ -252,6 +253,16 @@ func (a *API) MarkRead(ctx context.Context, id string) error {
 // MarkUnread marks a message as unread.
 func (a *API) MarkUnread(ctx context.Context, id string) error {
 	return a.email.MarkAsUnread(ctx, id)
+}
+
+// Star adds the STARRED label to a message.
+func (a *API) Star(ctx context.Context, id string) error {
+	return a.labels.ApplyLabel(ctx, id, "STARRED")
+}
+
+// Unstar removes the STARRED label from a message.
+func (a *API) Unstar(ctx context.Context, id string) error {
+	return a.labels.RemoveLabel(ctx, id, "STARRED")
 }
 
 // ListLabels returns all of the account's labels.
@@ -306,6 +317,7 @@ func (a *API) hydrate(page *services.MessagePage) (*MessageList, error) {
 			Snippet:  m.Snippet,
 			Date:     a.mail.ExtractDate(m),
 			Unread:   containsLabel(rawLabels, "UNREAD"),
+			Starred:  containsLabel(rawLabels, "STARRED"),
 			Labels:   a.resolveLabels(rawLabels),
 		})
 	}

--- a/pkg/desktop/dto.go
+++ b/pkg/desktop/dto.go
@@ -12,6 +12,7 @@ type MessageSummary struct {
 	Snippet  string    `json:"snippet"`
 	Date     time.Time `json:"date"`
 	Unread   bool      `json:"unread"`
+	Starred  bool      `json:"starred"`
 	Labels   []string  `json:"labels"`
 }
 
@@ -25,6 +26,7 @@ type MessageDetail struct {
 	Cc        string    `json:"cc"`
 	Date      time.Time `json:"date"`
 	Unread    bool      `json:"unread"`
+	Starred   bool      `json:"starred"`
 	Labels    []string  `json:"labels"`
 	PlainText string    `json:"plainText"`
 	HTML      string    `json:"html"`


### PR DESCRIPTION
# Pull Request

## 📋 **Description**

Closes #34. Adds a first-class star/unstar action so Gmail's STARRED label no longer has to be toggled through the generic labels picker.

**Key:** `*` toggles the star on the highlighted/open message (in bulk mode `*` keeps its existing "select all" meaning). **Commands:** `:star` / `:unstar` (aliases `:st` / `:unst`), plus `:star toggle`; bulk-aware in the TUI. **Indicator:** a `★` in the list.

Reuses the existing `LabelService` (`ApplyLabel`/`RemoveLabel`/`BulkApplyLabel`/`BulkRemoveLabel` with `STARRED`) — no new service or Gmail-client change.

### TUI (`internal/`)
- `*` → `toggleStar()` on the selected message (`keys.go`); `setStarCurrentMessage` / `toggleStar` / `starSelectedBulk` mirror the `toggle-read` pattern (cache update + `refreshTableDisplay`).
- `:star` / `:unstar` (+ `:star toggle`) in `commands.go`, bulk-aware; command-completion entries.
- `★` appended in `extractMessageFlags` (`render/email.go`); `?` help entry.

### Desktop (`pkg/desktop` + `desktop/`)
- `Star` / `Unstar` on the `*API` and the Wails `*App`; a `starred` field on the message DTOs (`MessageSummary` / `MessageDetail`).
- Frontend: `*` toggles the open message (`keydownMain`), `:star` / `:unstar` commands, a gold star SVG indicator in the list (`Icons.tsx` + `MessageList.tsx`), reflected **in place** (no refetch); Help entry; api.ts types + mock.

## 🏗️ **Architecture Compliance Checklist**

### ✅ **Service Layer**
- [x] Business logic stays in `internal/services` (`LabelService`); UI only calls it. Desktop reuses the same stack via `pkg/desktop`.

### ✅ **Error Handling**
- [x] TUI mirrors `toggle-read` (`showError`/`showStatusMessage`); bulk path uses `GetErrorHandler` progress/success/warning. No `fmt.Printf` for user messages.

### ✅ **Thread Safety**
- [x] API calls run in goroutines; cache/label updates via `updateCachedMessageLabels` inside `QueueUpdateDraw`; no `QueueUpdateDraw` in cleanup paths.

### ✅ **UI Components**
- [x] Presentation-only; delegates to the service. Desktop follows the `useMailActions` in-place-reflection pattern; star indicator uses a shared `Icon` (no emoji in UI chrome).

### ✅ **Command Parity**
- [x] `*` ↔ `:star` / `:unstar`; TUI commands support bulk. Registered in `executeCommand` + completion (TUI) and `COMMANDS` + `commandRunner` (desktop). In-app `?`/Help updated on both surfaces.

### ✅ **Config**
- [x] No new config key (uses the fixed `*`, consistent with `space`/`:`), so no migration needed. `S`/`s` were already `search_subject`/`search`, so `*` (the star glyph) was the natural, collision-free choice.

## 🧪 **Testing**
- [x] `make pre-commit-check` (fmt + vet + golangci-lint **0 issues** + tests)
- [x] `go build ./...` + `go -C desktop build ./...` + `go test ./internal/render ./internal/services ./pkg/desktop`
- [x] `cd desktop/frontend && npx tsc --noEmit && npm run build && npm test` (62) `&& npm run test:e2e` (**49**, incl. 2 new `star.spec.ts`)

## 📝 **Related Issues**
Closes #34.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU)_