### PR TITLE
feat(desktop): local usage-analytics dashboard (:stats) — TUI parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   high-value actions (archive, trash, summarize), so you can see success/failure
   rates and how long they take — complementing the command/shortcut counts which
   only measure invocation.
+- **Desktop parity for `:stats`.** The desktop client now has the same local,
+  opt-in usage-analytics dashboard (totals, top commands/shortcuts, and the
+  Actions section) reusing the same per-account store; `:stats reset` and
+  `:stats <days>` work there too. `:prompt stats` stays the AI prompt-usage view.
 
 ## [1.23.0] - 2026-07-31
 

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -243,6 +243,46 @@ func (a *App) GetThemeColors(name string) (*desktop.ThemeColors, error) {
 	return api.GetThemeColors(a.ctx, name)
 }
 
+// TelemetryEnabled reports whether local usage analytics are on (opt-in).
+func (a *App) TelemetryEnabled() bool {
+	return a.enabled((*desktop.API).TelemetryEnabled)
+}
+
+// RecordCommand records a command invocation (name only) for local analytics.
+// Fire-and-forget: silently ignored until the session is ready or when disabled.
+func (a *App) RecordCommand(name string) {
+	if api, err := a.api(); err == nil {
+		api.RecordCommand(name)
+	}
+}
+
+// RecordShortcut records a single shortcut keypress for local analytics.
+// Fire-and-forget, like RecordCommand.
+func (a *App) RecordShortcut(key string) {
+	if api, err := a.api(); err == nil {
+		api.RecordShortcut(key)
+	}
+}
+
+// TelemetrySummary returns the local usage-analytics dashboard data for the last
+// windowDays (0 → default 30).
+func (a *App) TelemetrySummary(windowDays int) (*desktop.TelemetrySummary, error) {
+	api, err := a.api()
+	if err != nil {
+		return nil, err
+	}
+	return api.TelemetrySummary(a.ctx, windowDays)
+}
+
+// TelemetryReset deletes all captured telemetry for the active account.
+func (a *App) TelemetryReset() error {
+	api, err := a.api()
+	if err != nil {
+		return err
+	}
+	return api.TelemetryReset(a.ctx)
+}
+
 // ApplyBulkPromptStream applies a prompt across many messages, streaming tokens
 // via the "prompt:token" event.
 func (a *App) ApplyBulkPromptStream(ids []string, promptID int) (string, error) {

--- a/desktop/frontend/e2e/modals.spec.ts
+++ b/desktop/frontend/e2e/modals.spec.ts
@@ -14,12 +14,15 @@ test.describe("display modals", () => {
     await expect(modal).toBeHidden();
   });
 
-  test("':stats' redirects to :prompt stats (not 'unknown command')", async ({ page }) => {
+  test("':stats' opens the local usage-analytics dashboard and Escape closes it", async ({ page }) => {
     await openApp(page);
     await runCommand(page, "stats");
-    const toast = page.locator(".toast");
-    await expect(toast).toContainText(":prompt stats");
-    await expect(toast).not.toContainText("Unknown command");
+    const modal = page.locator(".modal-overlay").filter({ hasText: "Usage analytics" });
+    await expect(modal).toBeVisible();
+    // The Actions section (outcomes + timing) is the telemetry-specific part.
+    await expect(modal).toContainText("Actions (outcome");
+    await page.keyboard.press("Escape");
+    await expect(modal).toBeHidden();
   });
 
   test("':config' opens the configuration modal and Escape closes it", async ({ page }) => {

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import {
   type KeyMap,
   type Label,
   type UsageStats,
+  type TelemetrySummary,
   type ConfigInfo,
   type MessageDetail,
   type MessageSummary,
@@ -118,6 +119,8 @@ export default function App() {
   } = useTheme();
   const [statsOpen, setStatsOpen] = useState(false);
   const [stats, setStats] = useState<UsageStats | null>(null);
+  const [telemetryOpen, setTelemetryOpen] = useState(false);
+  const [telemetry, setTelemetry] = useState<TelemetrySummary | null>(null);
   const [configOpen, setConfigOpen] = useState(false);
   const [configInfo, setConfigInfo] = useState<ConfigInfo | null>(null);
   // headersExpanded reveals the extra cc/thread/id detail (via the ⋯ menu).
@@ -386,13 +389,13 @@ export default function App() {
   });
 
   const {
-    openStats, openConfig, clearCaches, doMove, doBulkMove, quickSearch, openInGmail, saveMessage, saveRawMessage, openSuggest, applySuggestion, openQueries, runQuery, deleteQuery, doSaveQuery,
+    openStats, openTelemetry, resetTelemetry, openConfig, clearCaches, doMove, doBulkMove, quickSearch, openInGmail, saveMessage, saveRawMessage, openSuggest, applySuggestion, openQueries, runQuery, deleteQuery, doSaveQuery,
   } = useMiscActions({
     messages, selected, activeQuery, suggestFor, saveQueryName, showToast,
     setError, load, removeFromList, insertMessage, advanceAfterBulk, pushUndo,
     setBulkMove, setBulkProgress, setBusy, setConfigInfo, setConfigOpen, setLoadingSuggest,
     setMessages, setMoveFor, setQueriesOpen, setQuery, setSavedQueries, setSelected,
-    setStats, setStatsOpen, setSuggestFor, setSuggestions, setSaveQueryOpen, setSaveQueryName,
+    setStats, setStatsOpen, setTelemetry, setTelemetryOpen, setSuggestFor, setSuggestions, setSaveQueryOpen, setSaveQueryName,
   });
 
   const {
@@ -423,7 +426,7 @@ export default function App() {
     fullMessagesRef, gPressedAt, generateReply,
     headersHidden, imageOptIn, invite, keymap, labelsFor, linksFor,
     load, loadMore, localFilter, messages, moveFor, obsidianOn, openConfig,
-    openDrafts, openInGmail, openMessage, openQueries, openRules, openStats, openSuggest,
+    openDrafts, openInGmail, openMessage, openQueries, openRules, openStats, openTelemetry, resetTelemetry, openSuggest,
     plan, planActiveRef, planMove, planNodesRef, planOpen, planPreview, previewMessage,
     promptManagerOpen, promptPreview, promptsOpen, queriesOpen, query, quickSearch, readerBodyRef,
     readerFocused, regenerateActive, resetZoom, respondInvite, rsvpPickerOpen, rulesEnabled, rulesOpen,
@@ -437,8 +440,8 @@ export default function App() {
     setLabelsFor, setLinksFor, setLoadRemote, setLocalFilter, setMessages, setMoveFor, setPlanExcluded,
     setPlanMove, setPlanOpen, setPlanPreview, setPromptManagerOpen, setPromptPreview, setPromptsOpen, setQueriesOpen,
     setQuery, setReaderFocused, setRsvpPickerOpen, setRulesOpen, setSaveQueryOpen, setSelected, setSelectedId,
-    setShowHelp, setStatsOpen, setSuggestFor, setThemePickerOpen, setTouchUpText, setViewHtml, setZoom,
-    showHelp, showToast, slackOn, statsOpen, suggestFor, summarize, summarizeThread,
+    setShowHelp, setStatsOpen, setTelemetryOpen, setSuggestFor, setThemePickerOpen, setTouchUpText, setViewHtml, setZoom,
+    showHelp, showToast, slackOn, statsOpen, telemetryOpen, suggestFor, summarize, summarizeThread,
     themePickerOpen, themesOn, threadMsgs, threadingOn, toggleAutoRefresh, toggleSelect, toggleStar, toggleThread,
     toggleToolbar, touchUp, touchUpText, viewAnalyzerPrompt, vimRange,
   });
@@ -482,7 +485,8 @@ export default function App() {
     addRule, deleteRule, setRulesOpen, promptPreview, setPromptPreview, cmdOpen, executeCommand,
     setCmdOpen, themePickerOpen, themeNames, currentTheme, applyTheme, setThemePickerOpen, moveFor,
     labels, doMove, setMoveFor, bulkMove, doBulkMove, setBulkMove, advOpen, adv, setAdv,
-    setLocalFilter, setQuery, load, setAdvOpen, statsOpen, stats, setStatsOpen, configOpen, configInfo,
+    setLocalFilter, setQuery, load, setAdvOpen, statsOpen, stats, setStatsOpen,
+    telemetryOpen, telemetry, setTelemetryOpen, resetTelemetry, configOpen, configInfo,
     clearCaches, setConfigOpen, showHelp, keymap, obsidianOn, slackOn, threadingOn, savedQueriesOn,
     actionPlanOn, rsvpEnabled, themesOn, appVersion, setShowHelp,
   };

--- a/desktop/frontend/src/Help.tsx
+++ b/desktop/frontend/src/Help.tsx
@@ -230,6 +230,7 @@ function buildSections(k: KeyMap, f: HelpFlags): Section[] {
   }
   tools.push({ icon: "✕", keys: "Esc · :dismiss", desc: "Close the open AI panel" });
   tools.push({ icon: "▤", keys: ":toolbar", desc: "Show / hide reader toolbar" });
+  tools.push({ icon: "📊", keys: ":stats", desc: "Local usage analytics (opt-in)" });
   tools.push({ icon: "📊", keys: ":prompt stats", desc: "AI prompt usage" });
   tools.push({ icon: "🛠️", keys: ":config", desc: "Configuration" });
   tools.push({ icon: "⌨️", keys: fmtKey(k.commandMode), desc: "Command palette" });

--- a/desktop/frontend/src/ModalsSecondary.tsx
+++ b/desktop/frontend/src/ModalsSecondary.tsx
@@ -6,6 +6,7 @@ import type {
   MessageDetail,
   Label,
   UsageStats,
+  TelemetrySummary,
   ConfigInfo,
   KeyMap,
 } from "./apiTypes";
@@ -27,6 +28,7 @@ import ThemePicker from "./ThemePicker";
 import MovePicker from "./MovePicker";
 import AdvancedSearchModal from "./AdvancedSearchModal";
 import StatsModal from "./StatsModal";
+import TelemetryModal from "./TelemetryModal";
 import ConfigModal from "./ConfigModal";
 import Help from "./Help";
 import AiJobsPicker from "./AiJobsPicker";
@@ -116,6 +118,10 @@ export default function ModalsSecondary(p: {
   statsOpen: boolean;
   stats: UsageStats | null;
   setStatsOpen: Dispatch<SetStateAction<boolean>>;
+  telemetryOpen: boolean;
+  telemetry: TelemetrySummary | null;
+  setTelemetryOpen: Dispatch<SetStateAction<boolean>>;
+  resetTelemetry: () => Promise<void>;
   configOpen: boolean;
   configInfo: ConfigInfo | null;
   clearCaches: () => Promise<void>;
@@ -149,6 +155,7 @@ export default function ModalsSecondary(p: {
     applyTheme, setThemePickerOpen, showToast, moveFor, labels, doMove, setMoveFor,
     bulkMove, selected, doBulkMove, setBulkMove, advOpen, adv, setAdv,
     setLocalFilter, setQuery, load, setAdvOpen, statsOpen, stats, setStatsOpen,
+    telemetryOpen, telemetry, setTelemetryOpen, resetTelemetry,
     configOpen, configInfo, clearCaches, setConfigOpen, showHelp, keymap, aiEnabled,
     aiPromptsEnabled, obsidianOn, slackOn, threadingOn, savedQueriesOn,
     actionPlanOn, rsvpEnabled, themesOn, appVersion, setShowHelp,
@@ -361,6 +368,13 @@ export default function ModalsSecondary(p: {
       )}
       {statsOpen && (
         <StatsModal stats={stats} onClose={() => setStatsOpen(false)} />
+      )}
+      {telemetryOpen && (
+        <TelemetryModal
+          summary={telemetry}
+          onReset={() => void resetTelemetry()}
+          onClose={() => setTelemetryOpen(false)}
+        />
       )}
       {configOpen && (
         <ConfigModal

--- a/desktop/frontend/src/TelemetryModal.tsx
+++ b/desktop/frontend/src/TelemetryModal.tsx
@@ -1,0 +1,147 @@
+import type {
+  TelemetrySummary,
+  TelemetryNameCount,
+  TelemetryActionStat,
+} from "./apiTypes";
+
+// Local usage-analytics dashboard (opened by :stats), mirroring the TUI's
+// telemetry view. Pure display; data is fetched by the caller. All data is
+// local-only and never uploaded.
+
+function fmtDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function BarRow({
+  name,
+  count,
+  max,
+  detail,
+}: {
+  name: string;
+  count: number;
+  max: number;
+  detail?: string;
+}) {
+  const pct = max > 0 ? Math.max(4, Math.round((count / max) * 100)) : 0;
+  return (
+    <div className="tele-row">
+      <span className="tele-row-name" title={name}>
+        {name}
+      </span>
+      <span className="tele-bar-track">
+        <span className="tele-bar-fill" style={{ width: `${pct}%` }} />
+      </span>
+      {detail ? (
+        <span className="tele-row-detail">{detail}</span>
+      ) : (
+        <span className="tele-row-count">{count}</span>
+      )}
+    </div>
+  );
+}
+
+function Section({
+  title,
+  rows,
+}: {
+  title: string;
+  rows: TelemetryNameCount[];
+}) {
+  const max = rows.reduce((m, r) => Math.max(m, r.count), 0);
+  return (
+    <>
+      <div className="tele-section-title">{title}</div>
+      {rows.length === 0 ? (
+        <div className="tele-empty">(none yet)</div>
+      ) : (
+        rows.map((r) => <BarRow key={r.name} name={r.name} count={r.count} max={max} />)
+      )}
+    </>
+  );
+}
+
+function ActionsSection({ rows }: { rows: TelemetryActionStat[] }) {
+  const max = rows.reduce((m, r) => Math.max(m, r.count), 0);
+  return (
+    <>
+      <div className="tele-section-title">Actions (outcome · timing)</div>
+      {rows.length === 0 ? (
+        <div className="tele-empty">(none yet)</div>
+      ) : (
+        rows.map((r) => (
+          <BarRow
+            key={r.name}
+            name={r.name}
+            count={r.count}
+            max={max}
+            detail={`${r.count} runs · ${r.failures} failed · ${fmtDuration(r.avgDurationMs)} avg`}
+          />
+        ))
+      )}
+    </>
+  );
+}
+
+export default function TelemetryModal({
+  summary,
+  onReset,
+  onClose,
+}: {
+  summary: TelemetrySummary | null;
+  onReset: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="modal narrow"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") onClose();
+        }}
+      >
+        <div className="modal-head">
+          <h3>Usage analytics</h3>
+          <button className="ghost" onClick={onClose}>
+            ✕
+          </button>
+        </div>
+        <div className="modal-body">
+          {!summary ? (
+            <div className="placeholder">Loading…</div>
+          ) : summary.totalActions === 0 ? (
+            <div className="placeholder">
+              No activity captured yet. Telemetry is local-only and opt-in — keep
+              using GizTUI and your command/shortcut usage will appear here.
+            </div>
+          ) : (
+            <>
+              <div className="stats-summary">
+                <div className="stat-tile">
+                  <span className="stat-num">{summary.totalActions}</span>
+                  <span className="stat-label muted">total actions</span>
+                </div>
+                <div className="stat-tile">
+                  <span className="stat-num">{summary.totalErrors}</span>
+                  <span className="stat-label muted">errors</span>
+                </div>
+              </div>
+              <Section title="Top commands" rows={summary.topCommands} />
+              <Section title="Top shortcuts (keys)" rows={summary.topShortcuts} />
+              <ActionsSection rows={summary.topActions} />
+            </>
+          )}
+          <div className="foot-hint" style={{ marginTop: 12 }}>
+            last {summary?.windowDays ?? 30} days · local-only, never uploaded ·{" "}
+            <button className="ghost" onClick={onReset}>
+              :stats reset
+            </button>{" "}
+            · Esc close
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/frontend/src/apiMockB.ts
+++ b/desktop/frontend/src/apiMockB.ts
@@ -180,6 +180,39 @@ export const mockB: Partial<Backend> = {
       ],
     };
   },
+  async TelemetryEnabled() {
+    return true;
+  },
+  async TelemetrySummary(windowDays: number) {
+    return {
+      windowDays: windowDays || 30,
+      totalActions: 412,
+      totalErrors: 7,
+      topCommands: [
+        { name: "search", count: 96 },
+        { name: "archive", count: 74 },
+        { name: "labels", count: 41 },
+        { name: "summarize", count: 33 },
+        { name: "chat", count: 22 },
+      ],
+      topShortcuts: [
+        { name: "j", count: 210 },
+        { name: "k", count: 188 },
+        { name: "a", count: 74 },
+        { name: "s", count: 51 },
+      ],
+      topActions: [
+        { name: "archive", count: 74, failures: 0, avgDurationMs: 180 },
+        { name: "summarize", count: 33, failures: 2, avgDurationMs: 1420 },
+        { name: "trash", count: 18, failures: 1, avgDurationMs: 210 },
+      ],
+    };
+  },
+  async TelemetryReset() {
+    await new Promise((r) => setTimeout(r, 150));
+  },
+  async RecordCommand() {},
+  async RecordShortcut() {},
   async ClearCaches() {
     await new Promise((r) => setTimeout(r, 250));
   },

--- a/desktop/frontend/src/apiTypes.ts
+++ b/desktop/frontend/src/apiTypes.ts
@@ -164,6 +164,27 @@ export interface UsageStats {
   topPrompts: UsageStat[];
 }
 
+export interface TelemetryNameCount {
+  name: string;
+  count: number;
+}
+
+export interface TelemetryActionStat {
+  name: string;
+  count: number;
+  failures: number;
+  avgDurationMs: number;
+}
+
+export interface TelemetrySummary {
+  windowDays: number;
+  totalActions: number;
+  totalErrors: number;
+  topCommands: TelemetryNameCount[];
+  topShortcuts: TelemetryNameCount[];
+  topActions: TelemetryActionStat[];
+}
+
 export interface SlackChannel {
   id: string;
   name: string;
@@ -411,6 +432,11 @@ export interface Backend {
   InviteInfo(messageID: string): Promise<Invite>;
   RespondInvite(messageID: string, status: string): Promise<void>;
   UsageStats(): Promise<UsageStats>;
+  TelemetryEnabled(): Promise<boolean>;
+  TelemetrySummary(windowDays: number): Promise<TelemetrySummary>;
+  TelemetryReset(): Promise<void>;
+  RecordCommand(name: string): Promise<void>;
+  RecordShortcut(key: string): Promise<void>;
   ClearCaches(): Promise<void>;
   ConfigInfo(): Promise<ConfigInfo>;
   MigrateConfig(): Promise<string>;

--- a/desktop/frontend/src/commandCtx.ts
+++ b/desktop/frontend/src/commandCtx.ts
@@ -57,6 +57,8 @@ export interface CommandCtx {
   invite: Invite | null;
   respondInvite: (id: string, status: "accepted" | "tentative" | "declined") => Promise<void>;
   openStats: () => Promise<void>;
+  openTelemetry: (days?: number) => Promise<void>;
+  resetTelemetry: () => Promise<void>;
   openConfig: () => Promise<void>;
   clearCaches: () => Promise<void>;
   loadMore: () => Promise<void>;

--- a/desktop/frontend/src/commandRunner.ts
+++ b/desktop/frontend/src/commandRunner.ts
@@ -15,7 +15,7 @@ export function runCommand(input: string, ctx: CommandCtx) {
     doBulkMove, generateReply, quickSearch, themesOn, applyTheme, rulesEnabled,
     openRules, viewAnalyzerPrompt, toggleToolbar, touchUp, touchUpText, localFilter,
     applyLocalFilter, query, runUndo, toggleAutoRefresh, saveRawMessage, invite,
-    respondInvite, openStats, openConfig, clearCaches, loadMore, attachments,
+    respondInvite, openStats, openTelemetry, resetTelemetry, openConfig, clearCaches, loadMore, attachments,
     threadingOn, toggleThread, threadMsgs, summarizeThread, messages, previewMessage,
     accounts, applyLabelChange, bumpZoom, resetZoom, setZoom, dismissAI,
     regenerateActive, setError, setCompose, setSelected, setSelectedId, setMessages,
@@ -27,6 +27,11 @@ export function runCommand(input: string, ctx: CommandCtx) {
     setThemePickerOpen, alwaysImagesRef, imageOptIn, fullMessagesRef,
   } = ctx;
         const { cmd, arg } = parseCommand(input);
+      // Telemetry: record the command word only (never args), skipping bare
+      // numeric jumps (:5). No-op when telemetry is disabled. Fire-and-forget.
+      if (cmd && !/^\d+$/.test(cmd)) {
+        void backend.RecordCommand(cmd);
+      }
       const d = detail;
       // Move the cursor/preview to a 1-based row (shared by :g, :$ and :N).
       const gotoRow = (n1: number) => {
@@ -381,12 +386,18 @@ export function runCommand(input: string, ctx: CommandCtx) {
           setAdvOpen(true);
           break;
         case "stats":
-        case "usage":
-          // :stats is the TUI's (opt-in) telemetry dashboard, which the desktop
-          // doesn't have yet. Prompt-usage moved to :prompt stats — redirect
-          // rather than falling through to a bare "Unknown command".
-          showToast("Usage analytics is TUI-only for now · AI prompt usage: :prompt stats");
+        case "usage": {
+          // Local usage-analytics dashboard (TUI parity). ":stats reset" wipes it;
+          // ":stats <days>" sets the window. Prompt usage lives at ":prompt stats".
+          const a = arg.trim().toLowerCase();
+          if (a === "reset") {
+            void openTelemetry().then(() => resetTelemetry());
+          } else {
+            const days = parseInt(a, 10);
+            void openTelemetry(Number.isFinite(days) && days > 0 ? days : undefined);
+          }
           break;
+        }
         case "config":
         case "cfg":
           // ":config migrate" runs the config self-migration (TUI parity);

--- a/desktop/frontend/src/commands.ts
+++ b/desktop/frontend/src/commands.ts
@@ -51,6 +51,7 @@ export const COMMANDS: CommandDef[] = [
   { names: ["unread", "u"], desc: "Show unread only" },
   { names: ["advanced", "adv"], desc: "Advanced search builder" },
   { names: ["local"], desc: "Toggle local filter / Gmail search" },
+  { names: ["stats", "usage"], desc: "Local usage analytics (:stats reset · :stats <days>)" },
   { names: ["config", "cfg"], desc: "Show configuration (:config migrate to update)" },
   { names: ["cache"], desc: "Clear AI caches" },
   { names: ["archive", "a"], desc: "Archive message" },

--- a/desktop/frontend/src/keydownCtx.ts
+++ b/desktop/frontend/src/keydownCtx.ts
@@ -141,6 +141,7 @@ export interface KeydownCtx {
   setSelectedId: Dispatch<SetStateAction<string | null>>;
   setShowHelp: Dispatch<SetStateAction<boolean>>;
   setStatsOpen: Dispatch<SetStateAction<boolean>>;
+  setTelemetryOpen: Dispatch<SetStateAction<boolean>>;
   setSuggestFor: Dispatch<SetStateAction<string | null>>;
   setThemePickerOpen: (v: boolean) => void;
   setViewHtml: Dispatch<SetStateAction<boolean>>;
@@ -148,6 +149,7 @@ export interface KeydownCtx {
   showToast: (m: string) => void;
   slackOn: boolean;
   statsOpen: boolean;
+  telemetryOpen: boolean;
   suggestFor: string | null;
   summarize: (id: string, force?: boolean) => Promise<void>;
   themePickerOpen: boolean;

--- a/desktop/frontend/src/keydownHandler.ts
+++ b/desktop/frontend/src/keydownHandler.ts
@@ -20,7 +20,7 @@ export function handleKeyDown(e: KeyboardEvent, ctx: KeydownCtx) {
     setLocalFilter, setMessages, setMoveFor, setPlanExcluded, setPlanMove, setPlanOpen,
     setPlanPreview, setPromptManagerOpen, setPromptPreview, setPromptsOpen, setQueriesOpen, setQuery,
     setRsvpPickerOpen, setRulesOpen, setSaveQueryOpen, setShowHelp, setStatsOpen, setSuggestFor,
-    setThemePickerOpen, showHelp, statsOpen, suggestFor, themePickerOpen, viewAnalyzerPrompt,
+    setThemePickerOpen, showHelp, statsOpen, telemetryOpen, setTelemetryOpen, suggestFor, themePickerOpen, viewAnalyzerPrompt,
     attachmentsOpen, activeQuery, jobsPickerOpen, setJobsPickerOpen,
     slackForwardOpen, setSlackForwardOpen, obsidianOpen, setObsidianOpen,
   } = ctx;
@@ -93,6 +93,7 @@ export function handleKeyDown(e: KeyboardEvent, ctx: KeydownCtx) {
         promptPreview !== null ||
         advOpen ||
         statsOpen ||
+        telemetryOpen ||
         configOpen ||
         moveFor ||
         bulkMove ||
@@ -123,6 +124,7 @@ export function handleKeyDown(e: KeyboardEvent, ctx: KeydownCtx) {
           else if (suggestFor) setSuggestFor(null);
           else if (advOpen) setAdvOpen(false);
           else if (statsOpen) setStatsOpen(false);
+          else if (telemetryOpen) setTelemetryOpen(false);
           else if (configOpen) setConfigOpen(false);
           else if (planPreview) setPlanPreview(null);
           else if (planMove) setPlanMove(null);

--- a/desktop/frontend/src/keydownMain.ts
+++ b/desktop/frontend/src/keydownMain.ts
@@ -310,6 +310,12 @@ export function handleKeyMain(e: KeyboardEvent, ctx: KeydownCtx) {
       const action = chordAction[chord];
       if (!action) return;
       e.preventDefault();
+      // Telemetry: record the shortcut key (no-op when disabled). Skip the
+      // command-bar trigger — the command typed after it is captured on its own,
+      // so counting the key too would double-count. Fire-and-forget.
+      if (action !== "commandMode") {
+        void backend.RecordShortcut(chord);
+      }
       switch (action) {
         case "summarize":
           if (detail && aiEnabled && !bulkMode) void summarize(detail.id);

--- a/desktop/frontend/src/styles/04-modals.css
+++ b/desktop/frontend/src/styles/04-modals.css
@@ -182,6 +182,56 @@
   color: var(--accent);
 }
 
+/* Usage analytics (telemetry) dashboard */
+.tele-section-title {
+  font-weight: 700;
+  font-size: 13px;
+  margin: 14px 0 4px;
+}
+.tele-empty {
+  font-size: 13px;
+  opacity: 0.6;
+  padding: 4px 0 6px;
+}
+.tele-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 2px;
+}
+.tele-row-name {
+  width: 96px;
+  flex: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tele-bar-track {
+  flex: 1;
+  height: 10px;
+  background: var(--bg-elev);
+  border-radius: 5px;
+  overflow: hidden;
+}
+.tele-bar-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 5px;
+}
+.tele-row-count {
+  width: 40px;
+  flex: none;
+  text-align: right;
+  font-weight: 600;
+  color: var(--accent);
+}
+.tele-row-detail {
+  flex: none;
+  font-size: 12px;
+  opacity: 0.75;
+  white-space: nowrap;
+}
+
 /* Config panel */
 .config-list {
   display: flex;

--- a/desktop/frontend/src/useMiscActions.ts
+++ b/desktop/frontend/src/useMiscActions.ts
@@ -1,6 +1,6 @@
 import { useCallback, type Dispatch, type SetStateAction } from "react";
 import { backend } from "./api";
-import type { MessageSummary, MessageDetail, ConfigInfo, SavedQuery, UsageStats } from "./apiTypes";
+import type { MessageSummary, MessageDetail, ConfigInfo, SavedQuery, UsageStats, TelemetrySummary } from "./apiTypes";
 import { emailAddr, cleanSubject } from "./format";
 
 // useMiscActions groups the smaller action handlers: usage-stats / config /
@@ -34,6 +34,8 @@ export function useMiscActions(deps: {
   setSelected: Dispatch<SetStateAction<Set<string>>>;
   setStats: Dispatch<SetStateAction<UsageStats | null>>;
   setStatsOpen: Dispatch<SetStateAction<boolean>>;
+  setTelemetry: Dispatch<SetStateAction<TelemetrySummary | null>>;
+  setTelemetryOpen: Dispatch<SetStateAction<boolean>>;
   setSuggestFor: Dispatch<SetStateAction<string | null>>;
   setSuggestions: Dispatch<SetStateAction<string[]>>;
   setSaveQueryOpen: Dispatch<SetStateAction<boolean>>;
@@ -44,13 +46,36 @@ export function useMiscActions(deps: {
     showToast, setError, load, removeFromList, insertMessage, advanceAfterBulk,
     pushUndo, setBulkMove, setBulkProgress, setBusy, setConfigInfo, setConfigOpen,
     setLoadingSuggest, setMessages, setMoveFor, setQueriesOpen, setQuery, setSavedQueries,
-    setSelected, setStats, setStatsOpen, setSuggestFor, setSuggestions,
+    setSelected, setStats, setStatsOpen, setTelemetry, setTelemetryOpen, setSuggestFor, setSuggestions,
     setSaveQueryOpen, setSaveQueryName,
   } = deps;
   const openStats = useCallback(async () => {
     setStatsOpen(true);
     try {
       setStats(await backend.UsageStats());
+    } catch (e) {
+      setError(String(e));
+    }
+  }, []);
+
+  // Local usage-analytics dashboard (:stats). Fetches the summary for the given
+  // window (default 30 days) and opens the modal.
+  const openTelemetry = useCallback(async (days?: number) => {
+    setTelemetry(null);
+    setTelemetryOpen(true);
+    try {
+      setTelemetry(await backend.TelemetrySummary(days ?? 30));
+    } catch (e) {
+      setError(String(e));
+    }
+  }, []);
+
+  // :stats reset — wipe local telemetry, then refresh the open dashboard.
+  const resetTelemetry = useCallback(async () => {
+    try {
+      await backend.TelemetryReset();
+      setTelemetry(await backend.TelemetrySummary(30));
+      showToast("Usage analytics reset");
     } catch (e) {
       setError(String(e));
     }
@@ -242,6 +267,6 @@ export function useMiscActions(deps: {
   }, [saveQueryName, activeQuery, showToast]);
 
   return {
-    openStats, openConfig, clearCaches, doMove, doBulkMove, quickSearch, openInGmail, saveMessage, saveRawMessage, openSuggest, applySuggestion, openQueries, runQuery, deleteQuery, doSaveQuery,
+    openStats, openTelemetry, resetTelemetry, openConfig, clearCaches, doMove, doBulkMove, quickSearch, openInGmail, saveMessage, saveRawMessage, openSuggest, applySuggestion, openQueries, runQuery, deleteQuery, doSaveQuery,
   };
 }

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -118,9 +118,16 @@ Prompt-template usage stats are separate and live under `:prompt stats`.
 
 ## 🧭 Scope & roadmap
 
-**TUI-only** so far. Captures commands, shortcuts, and error counts, plus
-per-action **outcome + timing** for a handful of high-value actions (`action`
-events with `ok` and `duration_ms`: archive, trash, summarize).
+Captures commands, shortcuts, and error counts, plus per-action **outcome +
+timing** for a handful of high-value actions (`action` events with `ok` and
+`duration_ms`: archive, trash, summarize).
+
+**TUI and desktop** both have the `:stats` dashboard now. The desktop reuses the
+same `TelemetryService`/store (per-account, opt-in): action outcomes are recorded
+in the backend (`pkg/desktop`), while command and shortcut capture come from the
+frontend via the `RecordCommand`/`RecordShortcut` bindings. The command-bar
+trigger is excluded on both, and errors are not captured on the desktop yet.
+
 Deferred (epic #41): **more instrumented actions** (send, search), **reports**
-(weekly/monthly), **CSV/JSON export**, `ctrl+…` shortcut capture, and **desktop
-parity**.
+(weekly/monthly), **CSV/JSON export**, `ctrl+…` shortcut capture, and desktop
+**error** capture.

--- a/pkg/desktop/ai.go
+++ b/pkg/desktop/ai.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/ajramos/giztui/internal/render"
 	"github.com/ajramos/giztui/internal/services"
@@ -40,10 +41,12 @@ func (a *API) Summarize(ctx context.Context, id string) (string, error) {
 	if strings.TrimSpace(content) == "" {
 		return "", fmt.Errorf("message has no readable content to summarize")
 	}
+	start := time.Now()
 	res, err := a.ai.GenerateSummary(ctx, content, services.SummaryOptions{
 		MessageID:    id,
 		AccountEmail: a.accountEmail,
 	})
+	a.recordAction("summarize", start, err)
 	if err != nil {
 		return "", err
 	}
@@ -66,6 +69,7 @@ func (a *API) SummarizeStream(ctx context.Context, id string, force bool, onToke
 	if strings.TrimSpace(content) == "" {
 		return "", fmt.Errorf("message has no readable content to summarize")
 	}
+	start := time.Now()
 	res, err := a.ai.GenerateSummaryStream(ctx, content, services.SummaryOptions{
 		MessageID:       id,
 		AccountEmail:    a.accountEmail,
@@ -73,6 +77,7 @@ func (a *API) SummarizeStream(ctx context.Context, id string, force bool, onToke
 		UseCache:        !force,
 		ForceRegenerate: force,
 	}, onToken)
+	a.recordAction("summarize", start, err)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/desktop/api.go
+++ b/pkg/desktop/api.go
@@ -62,6 +62,7 @@ type Deps struct {
 	Invite       inviteClient                       // optional; calendar invite detection (gmail client)
 	Cal          calClient                          // optional; calendar RSVP responder
 	Cache        services.CacheService              // optional; summary cache (for clearing)
+	Telemetry    services.TelemetryService          // optional; local usage analytics (opt-in)
 	AccountEmail string                             // active account address, used as the "from" for sends
 	// Inbox-analyzer knobs, mirrored from config.InboxAnalyzer so the desktop
 	// honors the same settings as the TUI (0 → sensible defaults).
@@ -98,6 +99,7 @@ type API struct {
 	invite       inviteClient
 	cal          calClient
 	cache        services.CacheService
+	telemetry    services.TelemetryService
 	accountEmail string
 
 	analyzerBatchSize    int
@@ -137,6 +139,7 @@ func NewAPI(d Deps) *API {
 		invite:       d.Invite,
 		cal:          d.Cal,
 		cache:        d.Cache,
+		telemetry:    d.Telemetry,
 		accountEmail: d.AccountEmail,
 
 		analyzerBatchSize:    d.AnalyzerBatchSize,
@@ -237,12 +240,18 @@ func (a *API) GetMessage(ctx context.Context, id string) (*MessageDetail, error)
 
 // Archive removes the INBOX label from a message.
 func (a *API) Archive(ctx context.Context, id string) error {
-	return a.email.ArchiveMessage(ctx, id)
+	start := time.Now()
+	err := a.email.ArchiveMessage(ctx, id)
+	a.recordAction("archive", start, err)
+	return err
 }
 
 // Trash moves a message to the Gmail trash.
 func (a *API) Trash(ctx context.Context, id string) error {
-	return a.email.TrashMessage(ctx, id)
+	start := time.Now()
+	err := a.email.TrashMessage(ctx, id)
+	a.recordAction("trash", start, err)
+	return err
 }
 
 // MarkRead marks a message as read.

--- a/pkg/desktop/dto.go
+++ b/pkg/desktop/dto.go
@@ -171,6 +171,32 @@ type UsageStats struct {
 	TopPrompts    []UsageStat `json:"topPrompts"`
 }
 
+// TelemetryNameCount is a name and how many times it occurred (top commands /
+// shortcuts in the usage dashboard).
+type TelemetryNameCount struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+// TelemetryActionStat is an instrumented action's outcome: runs, failures, and
+// average duration in milliseconds.
+type TelemetryActionStat struct {
+	Name          string `json:"name"`
+	Count         int    `json:"count"`
+	Failures      int    `json:"failures"`
+	AvgDurationMs int    `json:"avgDurationMs"`
+}
+
+// TelemetrySummary is the aggregated local usage-analytics view for ":stats".
+type TelemetrySummary struct {
+	WindowDays   int                   `json:"windowDays"`
+	TotalActions int                   `json:"totalActions"`
+	TotalErrors  int                   `json:"totalErrors"`
+	TopCommands  []TelemetryNameCount  `json:"topCommands"`
+	TopShortcuts []TelemetryNameCount  `json:"topShortcuts"`
+	TopActions   []TelemetryActionStat `json:"topActions"`
+}
+
 // ConfigInfo is a read-only snapshot of the effective configuration, shown by
 // the desktop's ":config" panel.
 type ConfigInfo struct {

--- a/pkg/desktop/session.go
+++ b/pkg/desktop/session.go
@@ -95,6 +95,10 @@ type Session struct {
 
 // Close releases the session's resources (e.g. the local database).
 func (s *Session) Close() error {
+	// Drain buffered telemetry to disk before the database is closed under it.
+	if s.API != nil && s.API.telemetry != nil {
+		s.API.telemetry.Close()
+	}
 	if s.dbManager != nil {
 		return s.dbManager.Close()
 	}
@@ -285,6 +289,13 @@ func buildAPI(ctx context.Context, cfg *config.Config, client *gmail.Client, dbM
 	// Theming: read the user's theme from config (best-effort).
 	themeService := buildThemeService(cfg)
 
+	// Local usage analytics (opt-in). Needs the account DB; a no-op recorder when
+	// telemetry.enabled is false. Mirrors the TUI's per-account wiring.
+	var telemetryService services.TelemetryService
+	if dbStore != nil {
+		telemetryService = services.NewTelemetryService(db.NewTelemetryStore(dbStore), cfg, accountEmail)
+	}
+
 	return NewAPI(Deps{
 		Repo:         repo,
 		Email:        emailService,
@@ -309,6 +320,7 @@ func buildAPI(ctx context.Context, cfg *config.Config, client *gmail.Client, dbM
 		Invite:       client,
 		Cal:          cal,
 		Cache:        cacheService,
+		Telemetry:    telemetryService,
 		AccountEmail: accountEmail,
 		// Honor the same inbox-analyzer settings the TUI reads from config, so
 		// tuning inbox_analyzer.batch_size in config.json affects the desktop too.

--- a/pkg/desktop/telemetry.go
+++ b/pkg/desktop/telemetry.go
@@ -1,0 +1,87 @@
+package desktop
+
+import (
+	"context"
+	"time"
+)
+
+// Local, opt-in usage analytics for the desktop, mirroring the TUI. Capture is a
+// no-op unless the user turned telemetry on in config; nothing is ever uploaded.
+// Commands and shortcuts are recorded from the frontend (RecordCommand /
+// RecordShortcut); action outcomes (archive/trash/summarize) are recorded in the
+// backend methods via recordAction.
+
+// TelemetryEnabled reports whether local usage analytics are on (opt-in).
+func (a *API) TelemetryEnabled() bool {
+	return a.telemetry != nil && a.telemetry.IsEnabled()
+}
+
+// RecordCommand records a command invocation by its bare name (no arguments).
+// No-op when telemetry is disabled.
+func (a *API) RecordCommand(name string) {
+	if a.telemetry != nil {
+		a.telemetry.RecordEvent("command", name, true)
+	}
+}
+
+// RecordShortcut records a single keyboard shortcut keypress. No-op when
+// telemetry is disabled.
+func (a *API) RecordShortcut(key string) {
+	if a.telemetry != nil {
+		a.telemetry.RecordEvent("shortcut", key, true)
+	}
+}
+
+// recordAction records the outcome (ok + wall-clock duration) of a named backend
+// action. No-op when telemetry is disabled.
+func (a *API) recordAction(name string, start time.Time, err error) {
+	if a.telemetry != nil {
+		a.telemetry.RecordAction(name, err == nil, time.Since(start).Milliseconds())
+	}
+}
+
+// TelemetrySummary aggregates local usage over the last windowDays for the
+// ":stats" dashboard. Returns an empty summary when telemetry is unavailable.
+func (a *API) TelemetrySummary(ctx context.Context, windowDays int) (*TelemetrySummary, error) {
+	if windowDays <= 0 {
+		windowDays = 30
+	}
+	if a.telemetry == nil {
+		return &TelemetrySummary{WindowDays: windowDays}, nil
+	}
+	s, err := a.telemetry.Summary(ctx, windowDays)
+	if err != nil {
+		return nil, err
+	}
+	out := &TelemetrySummary{
+		WindowDays:   s.WindowDays,
+		TotalActions: s.TotalActions,
+		TotalErrors:  s.TotalErrors,
+		TopCommands:  make([]TelemetryNameCount, 0, len(s.TopCommands)),
+		TopShortcuts: make([]TelemetryNameCount, 0, len(s.TopShortcuts)),
+		TopActions:   make([]TelemetryActionStat, 0, len(s.TopActions)),
+	}
+	for _, c := range s.TopCommands {
+		out.TopCommands = append(out.TopCommands, TelemetryNameCount{Name: c.Name, Count: c.Count})
+	}
+	for _, k := range s.TopShortcuts {
+		out.TopShortcuts = append(out.TopShortcuts, TelemetryNameCount{Name: k.Name, Count: k.Count})
+	}
+	for _, ac := range s.TopActions {
+		out.TopActions = append(out.TopActions, TelemetryActionStat{
+			Name:          ac.Name,
+			Count:         ac.Count,
+			Failures:      ac.Failures,
+			AvgDurationMs: ac.AvgDurationMs,
+		})
+	}
+	return out, nil
+}
+
+// TelemetryReset deletes all captured telemetry for the active account.
+func (a *API) TelemetryReset(ctx context.Context) error {
+	if a.telemetry == nil {
+		return nil
+	}
+	return a.telemetry.Reset(ctx)
+}

--- a/pkg/desktop/telemetry_test.go
+++ b/pkg/desktop/telemetry_test.go
@@ -1,0 +1,86 @@
+package desktop
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ajramos/giztui/internal/config"
+	"github.com/ajramos/giztui/internal/db"
+	"github.com/ajramos/giztui/internal/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTelemetry_CaptureAndSummary(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(ctx, filepath.Join(t.TempDir(), "tel.db"))
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	cfg := &config.Config{Telemetry: config.TelemetryConfig{Enabled: true, RetentionDays: 90}}
+	tel := services.NewTelemetryService(db.NewTelemetryStore(store), cfg, "a@x")
+
+	api := NewAPI(Deps{Repo: &fakeRepo{}, Email: &fakeEmail{}, Mail: &fakeMail{}, Telemetry: tel})
+
+	// Action outcome (backend-instrumented) + command/shortcut capture (frontend
+	// bindings) all flow through the same recorder.
+	require.NoError(t, api.Archive(ctx, "m1"))
+	api.RecordCommand("search")
+	api.RecordCommand("search")
+	api.RecordShortcut("j")
+
+	// Deterministic flush before aggregation.
+	tel.Close()
+
+	sum, err := api.TelemetrySummary(ctx, 30)
+	require.NoError(t, err)
+	assert.Equal(t, 30, sum.WindowDays)
+	assert.Equal(t, 4, sum.TotalActions) // 1 action + 2 commands + 1 shortcut
+
+	require.NotEmpty(t, sum.TopActions)
+	assert.Equal(t, "archive", sum.TopActions[0].Name)
+	assert.Equal(t, 1, sum.TopActions[0].Count)
+	assert.Equal(t, 0, sum.TopActions[0].Failures)
+
+	require.NotEmpty(t, sum.TopCommands)
+	assert.Equal(t, "search", sum.TopCommands[0].Name)
+	assert.Equal(t, 2, sum.TopCommands[0].Count)
+
+	require.NotEmpty(t, sum.TopShortcuts)
+	assert.Equal(t, "j", sum.TopShortcuts[0].Name)
+}
+
+func TestTelemetry_DisabledIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(ctx, filepath.Join(t.TempDir(), "tel.db"))
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	cfg := &config.Config{Telemetry: config.TelemetryConfig{Enabled: false, RetentionDays: 90}}
+	tel := services.NewTelemetryService(db.NewTelemetryStore(store), cfg, "a@x")
+	api := NewAPI(Deps{Repo: &fakeRepo{}, Email: &fakeEmail{}, Mail: &fakeMail{}, Telemetry: tel})
+
+	assert.False(t, api.TelemetryEnabled())
+	require.NoError(t, api.Archive(ctx, "m1"))
+	api.RecordCommand("search")
+	tel.Close()
+
+	sum, err := api.TelemetrySummary(ctx, 30)
+	require.NoError(t, err)
+	assert.Equal(t, 0, sum.TotalActions)
+}
+
+// TestTelemetry_NilServiceSafe ensures the API tolerates no telemetry service
+// (e.g. no local DB) without panicking.
+func TestTelemetry_NilServiceSafe(t *testing.T) {
+	ctx := context.Background()
+	api := NewAPI(Deps{Repo: &fakeRepo{}, Email: &fakeEmail{}, Mail: &fakeMail{}})
+	assert.False(t, api.TelemetryEnabled())
+	require.NoError(t, api.Archive(ctx, "m1"))
+	api.RecordCommand("search")
+	api.RecordShortcut("j")
+	sum, err := api.TelemetrySummary(ctx, 30)
+	require.NoError(t, err)
+	assert.Equal(t, 0, sum.TotalActions)
+}


### PR DESCRIPTION
# Pull Request

## 📋 **Description**

Brings the **local, opt-in usage-analytics dashboard (`:stats`)** to the **desktop client**, for parity with the TUI (follow-up to #79, part of **#41**). Reuses the exact same per-account `TelemetryService` + SQLite store — **nothing is ever uploaded**.

- **Backend (`pkg/desktop`)** — wires `TelemetryService` into `Deps`/`API` + the session bootstrap (no-op recorder when `telemetry.enabled` is false), and **flushes on shutdown** (`Session.Close` drains before the DB closes). Adds:
  - `TelemetrySummary(days)` / `TelemetryReset()` + DTOs.
  - `RecordCommand` / `RecordShortcut` bindings (frontend capture).
  - Action **outcome + timing** instrumentation for **archive / trash / summarize** (`recordAction`, mirroring the TUI).
- **Desktop bindings (`desktop/app.go`)** — thin `*App` wrappers over the API.
- **Frontend** — a new **`TelemetryModal`** dashboard (totals, top commands, top shortcuts, and the **Actions** section with bars showing runs · failed · avg time). `:stats` opens it; `:stats reset` wipes; `:stats <days>` sets the window. `:prompt stats` stays the AI prompt-usage view.
  - Capture: command **names only** (in `runCommand`) and shortcut **keys** (in `keydownMain`), both excluding the command-bar trigger (no double-count); wired into the `anyModal` guard + Escape chain.
  - Help entry + command-palette entry; `api.ts` mock so browser dev still works.

## 🏗️ **Architecture Compliance Checklist**

### ✅ **Service Layer**
- [x] Reuses the TUI `TelemetryService` (`internal/services`) + `TelemetryStore` (`internal/db`) via `pkg/desktop`; no business logic in the frontend.

### ✅ **Error Handling**
- [x] Telemetry writes are best-effort and silent; user-facing errors (summary fetch / reset) go through the existing toast/error path. Capture bindings are fire-and-forget.

### ✅ **Thread Safety**
- [x] Capture is non-blocking (buffered channel, single owned goroutine); `Session.Close()` drains+flushes before the DB is closed.

### ✅ **UI Components**
- [x] `TelemetryModal` is presentational; data fetched via `useMiscActions` (`openTelemetry`/`resetTelemetry`). Follows the desktop modal premises (window-level Escape via `anyModal`, `✕` close).

### ✅ **Testing**
- [x] `pkg/desktop` tests: capture→summary (action + command + shortcut), disabled no-op, nil-service safety.
- [x] Playwright e2e: `:stats` opens the dashboard (Actions section) and Escape closes it.

## 🧪 **Testing**
- [x] `go build ./pkg/desktop/ && (cd desktop && go build ./...)`; `go test ./pkg/desktop/`; `make pre-commit-check` (fmt + vet + golangci-lint **0 issues** + tests)
- [x] Desktop frontend: `tsc --noEmit`, vitest (62), **full Playwright e2e (51)**, `vite build`
- [x] No regressions — existing `:prompt stats` (AI usage) unchanged

## 🔒 **Privacy**
- [x] Opt-in (default off); local-only per-account SQLite; **command args / message content never captured** (only bounded identifiers); no network path; `:stats reset` wipes; retention prunes automatically.

## 📝 **Related Issues**
Part of #41 (desktop parity follow-up to #79). Deferred: desktop **error** capture, reports, CSV/JSON export, more instrumented actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU)_