### PR TITLE
feat(desktop): message-number column (:numbers) — TUI parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   opt-in usage-analytics dashboard (totals, top commands/shortcuts, and the
   Actions section) reusing the same per-account store; `:stats reset` and
   `:stats <days>` work there too. `:prompt stats` stays the AI prompt-usage view.
+- **Desktop parity for message numbers (`:numbers`).** The desktop client can now
+  show a 1-based message-number column in the list, toggled with `:numbers` (alias
+  `:n`), so jumping with `:N` (e.g. `:14`) is easy to aim. The initial state is
+  seeded from `display.show_message_numbers` in config, mirroring the TUI.
 
 ## [1.23.0] - 2026-07-31
 

--- a/desktop/app_features.go
+++ b/desktop/app_features.go
@@ -13,6 +13,13 @@ func (a *App) ThreadingEnabled() bool {
 	return a.enabled((*desktop.API).ThreadingEnabled)
 }
 
+// ShowMessageNumbers reports the initial state of the list's message-number
+// column (config.display.show_message_numbers). The frontend seeds its :numbers
+// toggle from this at startup; false until a session is loaded.
+func (a *App) ShowMessageNumbers() bool {
+	return a.enabled((*desktop.API).ShowMessageNumbers)
+}
+
 // GetThread returns all messages in a thread for the conversation view.
 func (a *App) GetThread(threadID string) ([]desktop.MessageDetail, error) {
 	api, err := a.api()

--- a/desktop/frontend/e2e/numbers.spec.ts
+++ b/desktop/frontend/e2e/numbers.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+import { openApp, rows, runCommand } from "./helpers";
+
+// Message-number column (TUI :numbers parity). ':numbers' (alias ':n') toggles a
+// 1-based, right-aligned number column on each row so ':N' jumps like ':14' are
+// easy to aim. The mock's ShowMessageNumbers() returns false, so the column
+// starts hidden.
+test.describe("numbers", () => {
+  test("':numbers' toggles the message-number column", async ({ page }) => {
+    await openApp(page);
+    // Hidden by default (config-seeded off).
+    await expect(rows(page).nth(0).locator(".row-num")).toHaveCount(0);
+
+    // Toggle on: every row gets a number, the first row is "1".
+    await runCommand(page, "numbers");
+    await expect(rows(page).nth(0).locator(".row-num")).toHaveText("1");
+    await expect(rows(page).nth(1).locator(".row-num")).toHaveText("2");
+
+    // Toggle off again.
+    await runCommand(page, "numbers");
+    await expect(rows(page).nth(0).locator(".row-num")).toHaveCount(0);
+  });
+
+  test("':n' is an alias for ':numbers'", async ({ page }) => {
+    await openApp(page);
+    await runCommand(page, "n");
+    await expect(rows(page).nth(0).locator(".row-num")).toHaveText("1");
+  });
+});

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -80,6 +80,10 @@ export default function App() {
   const [switching, setSwitching] = useState(false);
   const [viewHtml, setViewHtml] = useState(false);
   const [loadRemote, setLoadRemote] = useState(false);
+  // Message-number column (TUI :numbers parity). Seeded from config at bootstrap;
+  // :numbers / :n toggles it in-memory (numbers make :N jumps like :14 aimable).
+  const [showNumbers, setShowNumbers] = useState(false);
+  const toggleNumbers = useCallback(() => setShowNumbers((v) => !v), []);
   // "Always load remote images": persisted global default (off = ask per message).
   const [alwaysImages, setAlwaysImages] = useState<boolean>(
     () => localStorage.getItem("giztui.alwaysImages") === "on",
@@ -336,7 +340,7 @@ export default function App() {
   const { importCreds, retryInit, switchAccount } = useBootstrap({
     load, initTheme, refreshIntegrations, setConnecting, setInitError, setNeedCreds,
     setAuthUrl, setCredsPath, setError, setAccount, setAiEnabled, setAiPromptsEnabled, setJobsNotify,
-    setAccounts, setKeymap, setAppVersion, setThreadingOn, setSavedQueriesOn, setActionPlanOn,
+    setAccounts, setKeymap, setAppVersion, setThreadingOn, setShowNumbers, setSavedQueriesOn, setActionPlanOn,
     setRulesEnabled, setLabels, setRsvpEnabled, setAutoRefreshSecs, setAutoRefresh, setImportErr,
     setImporting, setSwitching, setSelectedId, setDetail, setSummary, setPromptResult,
     setBulkMode, setSelected, setQuery,
@@ -442,7 +446,7 @@ export default function App() {
     setQuery, setReaderFocused, setRsvpPickerOpen, setRulesOpen, setSaveQueryOpen, setSelected, setSelectedId,
     setShowHelp, setStatsOpen, setTelemetryOpen, setSuggestFor, setThemePickerOpen, setTouchUpText, setViewHtml, setZoom,
     showHelp, showToast, slackOn, statsOpen, telemetryOpen, suggestFor, summarize, summarizeThread,
-    themePickerOpen, themesOn, threadMsgs, threadingOn, toggleAutoRefresh, toggleSelect, toggleStar, toggleThread,
+    themePickerOpen, themesOn, threadMsgs, threadingOn, toggleAutoRefresh, toggleNumbers, toggleSelect, toggleStar, toggleThread,
     toggleToolbar, touchUp, touchUpText, viewAnalyzerPrompt, vimRange,
   });
 
@@ -512,7 +516,7 @@ export default function App() {
     dismissSummary, promptPanelRef, promptLabel, promptResult, promptForId, aiCache, runPrompt,
     dismissPrompt, csOpen, csQuery, csIndex, setCsQuery, setCsIndex, setCsOpen, touchUpRef,
     dismissTouchUp, loadingThread, collapsedMsgs, setCollapsedMsgs, summarizeThread, loadingDetail,
-    loadRemote, setLoadRemote, imageOptIn, setAlwaysImagesOn, chat,
+    loadRemote, setLoadRemote, imageOptIn, setAlwaysImagesOn, chat, showNumbers,
   };
 
   return (

--- a/desktop/frontend/src/AppInbox.tsx
+++ b/desktop/frontend/src/AppInbox.tsx
@@ -159,6 +159,7 @@ export interface AppInboxProps {
   setLoadRemote: (v: boolean) => void;
   imageOptIn: MutableRefObject<Set<string>>;
   setAlwaysImagesOn: (on: boolean) => void;
+  showNumbers: boolean;
 }
 
 export default function AppInbox(p: AppInboxProps) {
@@ -181,7 +182,7 @@ export default function AppInbox(p: AppInboxProps) {
     dismissSummary, promptPanelRef, promptLabel, promptResult, promptForId, aiCache, runPrompt,
     dismissPrompt, csOpen, csQuery, csIndex, setCsQuery, setCsIndex, setCsOpen, touchUpRef,
     dismissTouchUp, loadingThread, collapsedMsgs, setCollapsedMsgs, summarizeThread, loadingDetail,
-    loadRemote, setLoadRemote, imageOptIn, setAlwaysImagesOn, chat,
+    loadRemote, setLoadRemote, imageOptIn, setAlwaysImagesOn, chat, showNumbers,
   } = p;
   return (
     <>
@@ -279,6 +280,7 @@ export default function AppInbox(p: AppInboxProps) {
           activeQuery={activeQuery}
           selectedId={selectedId}
           bulkMode={bulkMode}
+          showNumbers={showNumbers}
           selected={selected}
           busy={busy}
           bulkProgress={bulkProgress}

--- a/desktop/frontend/src/Help.tsx
+++ b/desktop/frontend/src/Help.tsx
@@ -56,6 +56,8 @@ function buildSections(k: KeyMap, f: HelpFlags): Section[] {
       { icon: "↵", keys: "Enter", desc: "Open message (marks read)" },
       { icon: "⬆️", keys: fmtKey(k.gotoTop), desc: "Go to top" },
       { icon: "⬇️", keys: fmtKey(k.gotoBottom), desc: "Go to bottom" },
+      { icon: "🔢", keys: ":numbers", desc: "Toggle message number column" },
+      { icon: "🎯", keys: ":5", desc: "Jump to message number 5" },
       { icon: "🔄", keys: fmtKey(k.refresh), desc: "Refresh inbox" },
       { icon: "⏬", keys: fmtKey(k.loadMore), desc: "Load more" },
       { icon: "🔍", keys: fmtKey(k.search), desc: "Search mail (Gmail)" },

--- a/desktop/frontend/src/MessageList.tsx
+++ b/desktop/frontend/src/MessageList.tsx
@@ -26,6 +26,7 @@ export default function MessageList({
   activeQuery,
   selectedId,
   bulkMode,
+  showNumbers,
   selected,
   busy,
   bulkProgress,
@@ -57,6 +58,7 @@ export default function MessageList({
   activeQuery: string;
   selectedId: string | null;
   bulkMode: boolean;
+  showNumbers: boolean;
   selected: Set<string>;
   busy: boolean;
   bulkProgress: string;
@@ -206,7 +208,7 @@ export default function MessageList({
           ) : (
             <>
               <ul>
-                {messages.map((m) => (
+                {messages.map((m, i) => (
                   <li
                     key={m.id}
                     className={
@@ -220,6 +222,19 @@ export default function MessageList({
                     }
                   >
                     <div className="row-top">
+                      {/* Message-number column (TUI :numbers parity): 1-based,
+                          right-aligned, width tracks the largest row number so
+                          :N jumps like :14 are easy to aim. */}
+                      {showNumbers && (
+                        <span
+                          className="row-num"
+                          style={{
+                            minWidth: `${String(messages.length).length}ch`,
+                          }}
+                        >
+                          {i + 1}
+                        </span>
+                      )}
                       {bulkMode && (
                         <span className="row-check">
                           {selected.has(m.id) ? "☑" : "☐"}

--- a/desktop/frontend/src/apiMockA.ts
+++ b/desktop/frontend/src/apiMockA.ts
@@ -251,6 +251,9 @@ export const mockA: Partial<Backend> = {
   async ThreadingEnabled() {
     return true;
   },
+  async ShowMessageNumbers() {
+    return false;
+  },
   async GetThread(_id: string) {
     const mk = (i: number, from: string, unread: boolean): MessageDetail => ({
       id: `t${i}`,

--- a/desktop/frontend/src/apiTypes.ts
+++ b/desktop/frontend/src/apiTypes.ts
@@ -383,6 +383,8 @@ export interface Backend {
   SwitchAccount(id: string): Promise<void>;
   KeyMap(): Promise<KeyMap>;
   ThreadingEnabled(): Promise<boolean>;
+  // Initial state of the list's message-number column (config-seeded); :numbers toggles it.
+  ShowMessageNumbers(): Promise<boolean>;
   GetThread(threadID: string): Promise<MessageDetail[]>;
   ThreadSummaryStream(threadID: string): Promise<string>;
   SavedQueriesEnabled(): Promise<boolean>;

--- a/desktop/frontend/src/commandCtx.ts
+++ b/desktop/frontend/src/commandCtx.ts
@@ -53,6 +53,7 @@ export interface CommandCtx {
   query: string;
   runUndo: () => Promise<void>;
   toggleAutoRefresh: () => void;
+  toggleNumbers: () => void;
   saveRawMessage: (id: string) => void;
   invite: Invite | null;
   respondInvite: (id: string, status: "accepted" | "tentative" | "declined") => Promise<void>;

--- a/desktop/frontend/src/commandRunner.ts
+++ b/desktop/frontend/src/commandRunner.ts
@@ -14,7 +14,7 @@ export function runCommand(input: string, ctx: CommandCtx) {
     runDeterministicRules, actionPlanOn, bulkMode, selected, bulkAction, showToast, doMove,
     doBulkMove, generateReply, quickSearch, themesOn, applyTheme, rulesEnabled,
     openRules, viewAnalyzerPrompt, toggleToolbar, touchUp, touchUpText, localFilter,
-    applyLocalFilter, query, runUndo, toggleAutoRefresh, saveRawMessage, invite,
+    applyLocalFilter, query, runUndo, toggleAutoRefresh, toggleNumbers, saveRawMessage, invite,
     respondInvite, openStats, openTelemetry, resetTelemetry, openConfig, clearCaches, loadMore, attachments,
     threadingOn, toggleThread, threadMsgs, summarizeThread, messages, previewMessage,
     accounts, applyLabelChange, bumpZoom, resetZoom, setZoom, dismissAI,
@@ -354,6 +354,12 @@ export function runCommand(input: string, ctx: CommandCtx) {
         case "autorefresh":
         case "arr":
           toggleAutoRefresh();
+          break;
+        case "numbers":
+        case "n":
+          // TUI parity: toggle the 1-based message-number column (makes :N jumps
+          // like :14 easy to aim). Seeded from config.display.show_message_numbers.
+          toggleNumbers();
           break;
         case "save-raw":
         case "saveraw":

--- a/desktop/frontend/src/commands.ts
+++ b/desktop/frontend/src/commands.ts
@@ -101,6 +101,7 @@ export const COMMANDS: CommandDef[] = [
   { names: ["label", "lbl"], desc: "Add label by name", arg: "<name>" },
   { names: ["select", "sel"], desc: "Bulk-select rows", arg: "all|none|<n|a-b>" },
   { names: ["goto", "g"], desc: "Go to row", arg: "[n]" },
+  { names: ["numbers", "n"], desc: "Toggle message number column (:5 jumps to row 5)" },
   { names: ["bottom", "end", "$"], desc: "Go to last row" },
   { names: ["queries"], desc: "Saved searches" },
   { names: ["savequery", "save-query", "sq"], desc: "Save current search" },

--- a/desktop/frontend/src/styles/01-base.css
+++ b/desktop/frontend/src/styles/01-base.css
@@ -277,6 +277,15 @@ button.danger {
   gap: 8px;
   margin-bottom: 2px;
 }
+.row-num {
+  flex: 0 0 auto;
+  text-align: right;
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  padding-right: 2px;
+  user-select: none;
+}
 .star-slot {
   flex: 0 0 auto;
   width: 15px;

--- a/desktop/frontend/src/useBootstrap.ts
+++ b/desktop/frontend/src/useBootstrap.ts
@@ -25,6 +25,7 @@ export function useBootstrap(deps: {
   setKeymap: (v: KeyMap) => void;
   setAppVersion: (v: string) => void;
   setThreadingOn: (v: boolean) => void;
+  setShowNumbers: (v: boolean) => void;
   setSavedQueriesOn: (v: boolean) => void;
   setActionPlanOn: (v: boolean) => void;
   setRulesEnabled: (v: boolean) => void;
@@ -46,7 +47,7 @@ export function useBootstrap(deps: {
   const {
     load, initTheme, refreshIntegrations, setConnecting, setInitError, setNeedCreds,
     setAuthUrl, setCredsPath, setError, setAccount, setAiEnabled, setAiPromptsEnabled, setJobsNotify,
-    setAccounts, setKeymap, setAppVersion, setThreadingOn, setSavedQueriesOn, setActionPlanOn,
+    setAccounts, setKeymap, setAppVersion, setThreadingOn, setShowNumbers, setSavedQueriesOn, setActionPlanOn,
     setRulesEnabled, setLabels, setRsvpEnabled, setAutoRefreshSecs, setAutoRefresh, setImportErr,
     setImporting, setSwitching, setSelectedId, setDetail, setSummary, setPromptResult,
     setBulkMode, setSelected, setQuery,
@@ -133,6 +134,7 @@ export function useBootstrap(deps: {
       try {
         await refreshIntegrations();
         setThreadingOn(await backend.ThreadingEnabled());
+        setShowNumbers(await backend.ShowMessageNumbers());
         setSavedQueriesOn(await backend.SavedQueriesEnabled());
         setActionPlanOn(await backend.ActionPlanEnabled());
         setRulesEnabled(await backend.AnalyzerRulesEnabled());

--- a/docs/DESKTOP_REFACTOR_PLAN.md
+++ b/docs/DESKTOP_REFACTOR_PLAN.md
@@ -268,6 +268,6 @@ Playwright net (**61 unit / 39 e2e**), re-verified with `tsc` + `build` + e2e ea
 - [ ] macOS **notarization** + Windows signing (phase 2 in `DESKTOP_DISTRIBUTION.md`)
   — the biggest user-facing friction (Gatekeeper/SmartScreen on unsigned builds).
 - [ ] Product decision: keep or remove **`:touch-up`** (user finds it unclear).
-- [ ] Minor TUI↔desktop command-parity gaps (`:numbers`, `:preload`, bookmarks).
+- [ ] Minor TUI↔desktop command-parity gaps (`:preload`, bookmarks). `:numbers` done.
 - [ ] Coverage baseline (2026-07-25): Go `internal/services` 32%, `pkg/desktop` 24%,
   `internal/tui` 9.7%; **frontend bootstrapped 0 → 38 unit tests**.

--- a/docs/KEYBOARD_SHORTCUTS.md
+++ b/docs/KEYBOARD_SHORTCUTS.md
@@ -78,6 +78,7 @@ Complete keyboard shortcut reference for GizTUI - the AI-powered Gmail terminal 
 | `G` | Go to last | Jump to last message |
 | `:5` + Enter | Jump to line | Jump to message number 5 |
 | `:$` + Enter | Jump to end | Jump to last message |
+| `:numbers` / `:n` | Toggle numbers | Toggle the 1-based message-number column (TUI & desktop) |
 
 ### Content Navigation (Within Message)
 | Key | Action | Description |

--- a/pkg/desktop/api.go
+++ b/pkg/desktop/api.go
@@ -69,7 +69,10 @@ type Deps struct {
 	AnalyzerBatchSize    int
 	AnalyzerMaxBatches   int
 	AnalyzerStrictLabels bool
-	Logger               *log.Logger
+	// ShowMessageNumbers mirrors config.Display.ShowMessageNumbers: the initial
+	// state of the message-number column the frontend can toggle with :numbers.
+	ShowMessageNumbers bool
+	Logger             *log.Logger
 }
 
 // API is the front-end-agnostic entry point. Every method returns
@@ -105,6 +108,7 @@ type API struct {
 	analyzerBatchSize    int
 	analyzerMaxBatches   int
 	analyzerStrictLabels bool
+	showMessageNumbers   bool
 
 	logger *log.Logger
 
@@ -145,6 +149,7 @@ func NewAPI(d Deps) *API {
 		analyzerBatchSize:    d.AnalyzerBatchSize,
 		analyzerMaxBatches:   d.AnalyzerMaxBatches,
 		analyzerStrictLabels: d.AnalyzerStrictLabels,
+		showMessageNumbers:   d.ShowMessageNumbers,
 
 		logger: d.Logger,
 	}
@@ -155,6 +160,11 @@ func (a *API) logf(format string, args ...interface{}) {
 		a.logger.Printf(format, args...)
 	}
 }
+
+// ShowMessageNumbers reports the initial state of the message-number column,
+// mirrored from config.Display.ShowMessageNumbers. The frontend seeds its
+// toggle from this at startup (TUI parity with :numbers).
+func (a *API) ShowMessageNumbers() bool { return a.showMessageNumbers }
 
 // ListInbox returns a page of inbox message summaries. Pass an empty pageToken
 // for the first page; use the returned NextPageToken to paginate.

--- a/pkg/desktop/api_test.go
+++ b/pkg/desktop/api_test.go
@@ -703,3 +703,13 @@ func TestScopeSearch(t *testing.T) {
 		}
 	}
 }
+
+func TestShowMessageNumbers(t *testing.T) {
+	// Off unless the config flag is set (mirrors config.Display.ShowMessageNumbers).
+	if api := NewAPI(Deps{Repo: &fakeRepo{}, Email: &fakeEmail{}, Mail: &fakeMail{}}); api.ShowMessageNumbers() {
+		t.Errorf("ShowMessageNumbers() = true, want false by default")
+	}
+	if api := NewAPI(Deps{Repo: &fakeRepo{}, Email: &fakeEmail{}, Mail: &fakeMail{}, ShowMessageNumbers: true}); !api.ShowMessageNumbers() {
+		t.Errorf("ShowMessageNumbers() = false, want true when config-enabled")
+	}
+}

--- a/pkg/desktop/session.go
+++ b/pkg/desktop/session.go
@@ -327,7 +327,10 @@ func buildAPI(ctx context.Context, cfg *config.Config, client *gmail.Client, dbM
 		AnalyzerBatchSize:    cfg.InboxAnalyzer.BatchSize,
 		AnalyzerMaxBatches:   cfg.InboxAnalyzer.MaxBatches,
 		AnalyzerStrictLabels: cfg.InboxAnalyzer.StrictLabels,
-		Logger:               logger,
+		// Seed the message-number column from config so the desktop honors the
+		// same display.show_message_numbers the TUI reads (:numbers toggles it).
+		ShowMessageNumbers: cfg.Display.ShowMessageNumbers,
+		Logger:             logger,
 	})
 }
 


### PR DESCRIPTION
# Pull Request

## 📋 **Description**

Brings the TUI's **`:numbers`** toggle to the **desktop client** (feature parity). Adds an optional **1-based, right-aligned message-number column** in the list, so jumping with `:N` (e.g. `:14`) is easy to aim — the bare numeric jump itself already worked in the desktop (`:5` / `:g N` / `:$`). The column's initial state is seeded from `display.show_message_numbers` in config, mirroring the TUI; **`:numbers`** (alias **`:n`**) toggles it in memory.

- **Backend (`pkg/desktop`)** — `Deps`/`API` gain `ShowMessageNumbers`, wired from `cfg.Display.ShowMessageNumbers` in `buildAPI`; `API.ShowMessageNumbers()` getter. Thin `*App` wrapper in `desktop/app_features.go` (same pattern as `ThreadingEnabled`).
- **Frontend** — bootstrap seeds `showNumbers` from `backend.ShowMessageNumbers()`; `App` owns the state + `toggleNumbers`; `:numbers`/`:n` wired through `commandCtx`/`commandRunner` and the command palette. `MessageList` renders a `.row-num` cell whose width tracks the largest row number. Help entry + `api` mock.

## 🏗️ **Architecture Compliance Checklist**

### ✅ **Service Layer**
- [x] No business logic in the frontend; the desktop reuses config via `pkg/desktop` (`API.ShowMessageNumbers()` reads the config-seeded flag). Display-only feature — no new service needed.

### ✅ **Error Handling**
- [x] N/A — pure display toggle; no user-facing error paths introduced.

### ✅ **Thread Safety**
- [x] Frontend React state (`showNumbers`) + a config-seeded read at bootstrap; no shared mutable Go state added.

### ✅ **UI Components**
- [x] `MessageList` stays presentational; the toggle lives in `App` and flows through the existing `inboxProps` forwarder. No emojis (SVG-icon convention respected; the number is text).

### ✅ **Testing**
- [x] `pkg/desktop` unit test: `ShowMessageNumbers()` reflects the config flag (default off, on when enabled).
- [x] Playwright e2e (`numbers.spec.ts`): `:numbers` toggles the column on/off; `:n` alias works.

## 🧪 **Testing**
- [x] `go build ./pkg/desktop/ && (cd desktop && go build ./...)`; `go test ./pkg/desktop/`; `make pre-commit-check` (fmt + vet + golangci-lint **0 issues** + tests)
- [x] Desktop module: `go vet ./...` + `golangci-lint run` (**0 issues**)
- [x] Frontend: `tsc --noEmit`, vitest (**62**), full Playwright e2e (**53**, incl. 2 new), `vite build`
- [x] Manually verified on macOS (`make dev`): `:numbers`/`:n` toggle the column, `:14` jumps, config seeding works
- [x] No regressions — bare numeric jumps and `:g`/`:$` unchanged

## 📝 **Related Issues**
Desktop parity follow-up (part of the TUI↔desktop parity effort). Closes the `:numbers` command-parity gap tracked in `docs/DESKTOP_REFACTOR_PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYZvP4iqhSnJi69CEdjcXU)_