### PR TITLE
fix(cask): use non-deprecated depends_on macos symbol form

### DIFF
--- a/docs/DESKTOP_DISTRIBUTION.md
+++ b/docs/DESKTOP_DISTRIBUTION.md
@@ -95,7 +95,7 @@ cask "giztui-desktop" do
   desc "Visual Gmail client (Wails) sharing the GizTUI service layer"
   homepage "https://github.com/ajramos/giztui"
   app "GizTUI Desktop.app"
-  depends_on macos: ">= :monterey"
+  depends_on macos: :monterey
   # Unsigned until Developer ID signing and notarization are configured.
 end
 ```

--- a/packaging/homebrew/giztui-desktop.rb
+++ b/packaging/homebrew/giztui-desktop.rb
@@ -23,7 +23,7 @@ cask "giztui-desktop" do
   desc "Visual Gmail client (Wails) sharing the GizTUI service layer"
   homepage "https://github.com/ajramos/giztui"
 
-  depends_on macos: ">= :monterey"
+  depends_on macos: :monterey
 
   app "GizTUI Desktop.app"
 


### PR DESCRIPTION
Homebrew warns on install:

> Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :monterey` instead.

The symbol form `:monterey` means "Monterey or later" — same requirement, non-deprecated syntax. Fixed in the cask template (propagates to future releases via the release workflow) and in the DESKTOP_DISTRIBUTION example. The live tap cask was already corrected directly (ajramos/homebrew-giztui@fdeeb00).